### PR TITLE
Dockerfile changes broke Sonic build

### DIFF
--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y libpcre3 libpcre3-dev byacc flex libgli
 RUN apt-get update && apt-get install -y libtool-bin libxml2-dev
 
 # For build image
-RUN apt-get update && apt-get install -y cpio
+RUN apt-get update && apt-get install -y cpio squashfs-tools zip
 
 # For broadcom sdk build
 RUN apt-get update && apt-get install -y linux-compiler-gcc-4.8-x86 linux-kbuild-3.16


### PR DESCRIPTION
The build process still requires squashfs-tools and zip to be installed in the Docker build environment.
Otherwise I see messages like:
mksquashfs: command not found  etc. pop up and the build fails.
The last commit removed the installation of these tools in the Dockerfile and this commit brings them back in.