### PR TITLE
[jenkins]: Resolve folder name conflicts in sonic-utilities-build

### DIFF
--- a/jenkins/common/sonic-utilities-build/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build/Jenkinsfile
@@ -82,9 +82,9 @@ cd ../../../
 
 docker save docker-sonic-vs | gzip -c > buildimage/target/docker-sonic-vs.gz
 
-git clone https://github.com/Azure/sonic-swss
+git clone https://github.com/Azure/sonic-swss sonic-swss-tests
 
-cd sonic-swss/tests
+cd sonic-swss-tests/tests
 sudo py.test -v
 '''
             }


### PR DESCRIPTION
```
+ git clone https://github.com/Azure/sonic-swss
fatal: destination path 'sonic-swss' already exists and is not an empty directory.
```