### PR TITLE
Work around the workspace cleanup issue of Jekins

### DIFF
--- a/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
@@ -42,7 +42,7 @@ sudo pip install pytest-runner==4.4
 cd sonic-utilities
 
 # Test building the Debian package
-sudo python setup.py --command-packages=stdeb.command bdist_deb
+sudo python setup.py --command-packages=stdeb.command bdist_deb; sudo chown $USER: -R .
 
 EOF
 

--- a/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
@@ -86,7 +86,7 @@ docker save docker-sonic-vs | gzip -c > buildimage/target/docker-sonic-vs.gz
 git clone https://github.com/Azure/sonic-swss sonic-swss-tests
 
 cd sonic-swss-tests/tests
-sudo py.test -v
+sudo py.test -v; sudo chown $USER: -R ..
 '''
             }
         }


### PR DESCRIPTION
Make generated files as root, so more easy to cleanup by Jenkins