### PR TITLE
[Jenkins] Install Click version >= 7.0 to fix sonic-utilities unit tests during build

### DIFF
--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -6,7 +6,8 @@ cat <<EOF > build_sonic_utilities.sh
 #!/bin/bash -xe
 ls -lrt
 
-sudo pip install click
+sudo apt-get -y purge python-click
+sudo pip install "click>=7.0"
 sudo pip install click-default-group==1.2
 sudo pip install tabulate
 sudo pip install natsort


### PR DESCRIPTION
During sonic-utilities builds on Jenkins, the unit tests in the sonic-utilities-tests directory of the sonic-utilities repo were failing with errors like,

```
AttributeError: 'Result' object has no attribute 'stdout'
```

This was because 'stdout' and 'stderr' were not added as members of the Result structure in the Python Click library until version 7.0. The slave container may contain an older version if installed via a .deb package, as it is the latest version available from Debian. However, since we need version 7.0 to run these tests, this patch will remove the Debian package and force an installation of Click >= 7.0 via pip.