### PR TITLE
Restart redis-server to load changes in redis.conf

### DIFF
--- a/scripts/common/sonic-swss-common-build/test.sh
+++ b/scripts/common/sonic-swss-common-build/test.sh
@@ -5,7 +5,7 @@ sudo apt-get install -y liblua5.1-0 lua-bitop lua-cjson
 sudo dpkg -i buildimage/target/debs/stretch/redis-tools_*.deb
 sudo dpkg -i buildimage/target/debs/stretch/redis-server_*.deb
 sudo sed -i 's/notify-keyspace-events ""/notify-keyspace-events AKE/' /etc/redis/redis.conf
-sudo service redis-server start
+sudo service redis-server restart
 
 sudo dpkg -i libswsscommon_*.deb
 sudo dpkg -i python-swsscommon_*.deb


### PR DESCRIPTION
redis-server starts once installation finishes here `sudo dpkg -i buildimage/target/debs/stretch/redis-server_*.deb` , so restarting redis-server is needed to involve redis.conf update.