### PR TITLE
[build] Adding back BGP speaker test

### DIFF
--- a/scripts/vs/buildimage-vs-image/runtest.sh
+++ b/scripts/vs/buildimage-vs-image/runtest.sh
@@ -25,6 +25,7 @@ tests_1vlan="\
     test_interfaces.py \
     test_bgp_fact.py \
     test_lldp.py \
+    test_bgp_speaker.py \
     test_dhcp_relay.py \
     snmp/test_snmp_cpu.py \
     snmp/test_snmp_interfaces.py \


### PR DESCRIPTION
BGP speaker test was taken out by commit 4365219c due to both test case and platform instabilities. PR https://github.com/Azure/sonic-mgmt/pull/1384 addressed platform issues and PR https://github.com/Azure/sonic-mgmt/pull/1387 addresses speaker test issues. Once the latter PR is pushed in, this PR will put back BGP speaker test.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>