### PR TITLE
[vs image] Add support for multiple test reports

### DIFF
--- a/jenkins/vs/buildimage-vs-image-test/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-test/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
     post {
 
         always {
-            junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/tr.xml')
+            junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/tr*.xml')
         }
 
         fixed {

--- a/scripts/vs/buildimage-vs-image/runtest.sh
+++ b/scripts/vs/buildimage-vs-image/runtest.sh
@@ -25,7 +25,6 @@ tests_1vlan="\
     test_interfaces.py \
     test_bgp_fact.py \
     test_lldp.py \
-    test_bgp_speaker.py \
     test_dhcp_relay.py \
     snmp/test_snmp_cpu.py \
     snmp/test_snmp_interfaces.py \
@@ -37,7 +36,7 @@ tests_1vlan="\
 # Run tests_1vlan on vlab-01 virtual switch
 ANSIBLE_LIBRARY=/data/sonic-mgmt/ansible/library/ \
     py.test --inventory veos.vtb --host-pattern all --user admin -vvv --show-capture stdout --testbed vms-kvm-t0 \
-            --testbed_file vtestbed.csv --disable_loganalyzer --junitxml=tr.xml $tests_1vlan
+            --testbed_file vtestbed.csv --disable_loganalyzer --junitxml=tr_1vlan.xml $tests_1vlan
 
 # Create and deploy two vlan configuration (two_vlan_a) to the virtual switch
 cd /data/sonic-mgmt/ansible
@@ -53,4 +52,4 @@ cd /data/sonic-mgmt/tests
 # Run tests_2vlans on vlab-01 virtual switch
 ANSIBLE_LIBRARY=/data/sonic-mgmt/ansible/library/ \
     py.test --inventory veos.vtb --host-pattern all --user admin -vvv --show-capture stdout --testbed vms-kvm-t0 \
-            --testbed_file vtestbed.csv --disable_loganalyzer --junitxml=tr.xml $tests_2vlans
+            --testbed_file vtestbed.csv --disable_loganalyzer --junitxml=tr_2vlans.xml $tests_2vlans

--- a/scripts/vs/buildimage-vs-image/runtest.sh
+++ b/scripts/vs/buildimage-vs-image/runtest.sh
@@ -25,6 +25,7 @@ tests_1vlan="\
     test_interfaces.py \
     test_bgp_fact.py \
     test_lldp.py \
+    test_bgp_speaker.py \
     test_dhcp_relay.py \
     snmp/test_snmp_cpu.py \
     snmp/test_snmp_interfaces.py \


### PR DESCRIPTION
With multiple test suites running in succession, the tr.xml get overwritten
with last test suite that run. With this change, every test suite will
produce its test report. Also, changing JUnit post API to pick up all
test reports generated.
    
signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>