### PR TITLE
[vs image] Add support for multiple test reports to buildimage-vs jobs

### DIFF
--- a/jenkins/vs/buildimage-vs-image-201911-test/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-201911-test/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
     post {
 
         always {
-            junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/tr.xml')
+            junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/tr*.xml')
         }
 
         fixed {

--- a/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
@@ -71,7 +71,7 @@ mv target ../
     post {
 
         always {
-            junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/tr.xml')
+            junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/tr*.xml')
             archiveArtifacts(artifacts: 'target/**')
         }
     }

--- a/jenkins/vs/buildimage-vs-image/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image/Jenkinsfile
@@ -75,7 +75,7 @@ mv target ../
     post {
 
         always {
-            junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/tr.xml')
+            junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/tr*.xml')
             archiveArtifacts(artifacts: 'target/**')
         }
 


### PR DESCRIPTION
Changing JUnit post API to pick up all test reports generated. A change was done earlier to generate multiple test reports in pr #79 
    
signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>