### PR TITLE
[swss build] Remove verbose debug logs from swss build

### DIFF
--- a/scripts/vs/sonic-swss-build/docker-sonic-vs/Dockerfile
+++ b/scripts/vs/sonic-swss-build/docker-sonic-vs/Dockerfile
@@ -10,14 +10,8 @@ RUN dpkg -i /debs/libsairedis_1.0.0_amd64.deb
 RUN dpkg -i /debs/libsaivs_1.0.0_amd64.deb
 RUN dpkg -i /debs/syncd-vs_1.0.0_amd64.deb
 
-RUN md5sum /debs/swss_1.0.0_amd64.deb
-RUN md5sum /usr/bin/buffermgrd
 RUN md5sum /usr/bin/orchagent
-
-RUN dpkg -i -D10 /debs/swss_1.0.0_amd64.deb
-
-RUN md5sum /debs/swss_1.0.0_amd64.deb
-RUN md5sum /usr/bin/buffermgrd
+RUN dpkg -i /debs/swss_1.0.0_amd64.deb
 RUN md5sum /usr/bin/orchagent
 
 ENTRYPOINT ["/usr/bin/supervisord"]


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

Removing the -D10 and some of the md5sums as we've finished investigating this issue. Leaving in the orchagent md5sum as an FYI, could also be useful for monitoring in the near-future.