### PR TITLE
Add LocalBranch to extentions in checkout step.

### DIFF
--- a/jenkins/barefoot/buildimage-bf-201904/Jenkinsfile
+++ b/jenkins/barefoot/buildimage-bf-201904/Jenkinsfile
@@ -21,7 +21,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/barefoot/buildimage-bf-201911/Jenkinsfile
+++ b/jenkins/barefoot/buildimage-bf-201911/Jenkinsfile
@@ -24,7 +24,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/broadcom/buildimage-brcm-201904/Jenkinsfile
+++ b/jenkins/broadcom/buildimage-brcm-201904/Jenkinsfile
@@ -14,14 +14,16 @@ pipeline {
     stages {
         stage('Prepare') {
             steps {
-                checkout([$class: 'GitSCM', 
-                          branches: [[name: 'refs/heads/201904']], 
+                checkout([$class: 'GitSCM',
+                          branches: [[name: 'refs/heads/201904']],
                           extensions: [[$class: 'SubmoduleOption',
                                         disableSubmodules: false,
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/broadcom/buildimage-brcm-all/Jenkinsfile
+++ b/jenkins/broadcom/buildimage-brcm-all/Jenkinsfile
@@ -24,7 +24,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/broadcom/buildimage-brcm-buster/Jenkinsfile
+++ b/jenkins/broadcom/buildimage-brcm-buster/Jenkinsfile
@@ -24,7 +24,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/lguohan/sonic-buildimage']]])
             }
         }

--- a/jenkins/generic/buildimage-baseimage/Jenkinsfile
+++ b/jenkins/generic/buildimage-baseimage/Jenkinsfile
@@ -28,7 +28,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
                 }
             }

--- a/jenkins/innovium/buildimage-invm-201811-rpc/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-201811-rpc/Jenkinsfile
@@ -21,7 +21,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/innovium/buildimage-invm-201811/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-201811/Jenkinsfile
@@ -21,7 +21,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/innovium/buildimage-invm-201911-rpc/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-201911-rpc/Jenkinsfile
@@ -21,7 +21,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/innovium/buildimage-invm-201911/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-201911/Jenkinsfile
@@ -24,7 +24,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/innovium/buildimage-invm-all-rpc/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-all-rpc/Jenkinsfile
@@ -22,7 +22,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/innovium/buildimage-invm-all/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-all/Jenkinsfile
@@ -25,7 +25,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/mellanox/buildimage-mlnx-201811-rpc/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-201811-rpc/Jenkinsfile
@@ -24,7 +24,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/mellanox/buildimage-mlnx-201811/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-201811/Jenkinsfile
@@ -24,7 +24,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/mellanox/buildimage-mlnx-201904/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-201904/Jenkinsfile
@@ -14,14 +14,16 @@ pipeline {
         stage('Prepare') {
             steps {
 
-                checkout([$class: 'GitSCM', 
-                          branches: [[name: 'refs/heads/201904']], 
+                checkout([$class: 'GitSCM',
+                          branches: [[name: 'refs/heads/201904']],
                           extensions: [[$class: 'SubmoduleOption',
                                         disableSubmodules: false,
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/mellanox/buildimage-mlnx-201911-rpc/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-201911-rpc/Jenkinsfile
@@ -24,7 +24,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/mellanox/buildimage-mlnx-201911/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-201911/Jenkinsfile
@@ -24,7 +24,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/mellanox/buildimage-mlnx-all-pr/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-all-pr/Jenkinsfile
@@ -9,8 +9,8 @@ pipeline {
         stage('Prepare') {
             steps {
                 step([$class: 'WsCleanup'])
-                checkout([$class: 'GitSCM', 
-                          branches: [[name: '${sha1}']], 
+                checkout([$class: 'GitSCM',
+                          branches: [[name: '${sha1}']],
                           extensions: [[$class: 'SubmoduleOption',
                                         disableSubmodules: false,
                                         parentCredentials: false,

--- a/jenkins/mellanox/buildimage-mlnx-all-rpc/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-all-rpc/Jenkinsfile
@@ -16,7 +16,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/mellanox/buildimage-mlnx-all/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-all/Jenkinsfile
@@ -24,7 +24,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/mellanox/buildimage-mlnx-bmtor-rpc/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-bmtor-rpc/Jenkinsfile
@@ -20,7 +20,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/mellanox/buildimage-mlnx-bmtor/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-bmtor/Jenkinsfile
@@ -20,7 +20,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/nephos/buildimage-nps-201811/Jenkinsfile
+++ b/jenkins/nephos/buildimage-nps-201811/Jenkinsfile
@@ -14,14 +14,16 @@ pipeline {
     stages {
         stage('Prepare') {
             steps {
-                checkout([$class: 'GitSCM', 
-                          branches: [[name: 'refs/heads/201811']], 
+                checkout([$class: 'GitSCM',
+                          branches: [[name: 'refs/heads/201811']],
                           extensions: [[$class: 'SubmoduleOption',
                                         disableSubmodules: false,
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/nephos/buildimage-nps-201911/Jenkinsfile
+++ b/jenkins/nephos/buildimage-nps-201911/Jenkinsfile
@@ -23,7 +23,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/nephos/buildimage-nps-all/Jenkinsfile
+++ b/jenkins/nephos/buildimage-nps-all/Jenkinsfile
@@ -24,7 +24,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/vs/buildimage-vs-all/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-all/Jenkinsfile
@@ -23,7 +23,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/vs/buildimage-vs-image-201904/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-201904/Jenkinsfile
@@ -14,14 +14,16 @@ pipeline {
     stages {
         stage('Prepare') {
             steps {
-                checkout([$class: 'GitSCM', 
-                          branches: [[name: 'refs/heads/201904']], 
+                checkout([$class: 'GitSCM',
+                          branches: [[name: 'refs/heads/201904']],
                           extensions: [[$class: 'SubmoduleOption',
                                         disableSubmodules: false,
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/vs/buildimage-vs-image-201911/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-201911/Jenkinsfile
@@ -23,7 +23,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
             }
         }

--- a/jenkins/vs/buildimage-vs-image-buster/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-buster/Jenkinsfile
@@ -31,7 +31,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/lguohan/sonic-buildimage']]])
                 }
             }

--- a/jenkins/vs/buildimage-vs-image/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image/Jenkinsfile
@@ -31,7 +31,9 @@ pipeline {
                                         parentCredentials: false,
                                         recursiveSubmodules: true,
                                         reference: '',
-                                        trackingSubmodules: false]],
+                                        trackingSubmodules: false],
+                                       [$class: 'LocalBranch',
+                                        localBranch: "**"]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage']]])
                 }
             }


### PR DESCRIPTION
SONiC build system inserts a branch name into image version string.
However, jenkins checkouts from the branch, so HEAD is in detached
state, in this case, "git rev-parse --abrrev-ref HEAD" returns HEAD.
This diff adds "LocalBranch" to extenstions, so jenkins will checkout
and create a local branch named as remote branch, this should fix the
issue with image version string.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>