### PR TITLE
Fix URL to SONiC Jenkins build link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Software for Open Networking in the Cloud - SONiC
 
-This repo manages the jenkins pipeline/script for public sonic jenkins build [site](https://sonic-jenkins.westus.cloudapp.azure.com/).
+This repo manages the jenkins pipeline/script for public sonic jenkins build [site](https://sonic-jenkins.westus2.cloudapp.azure.com/).
 
 # Contribution guide
 See  [SONiC contributors guide](https://azure.github.io/SONiC/CONTRIBUTING.md) for complete information.


### PR DESCRIPTION
Verified that the updated link works.