### PR TITLE
Enable wcache for buildimage-mlnx-all-rpc build job

### DIFF
--- a/jenkins/mellanox/buildimage-mlnx-all-rpc/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-all-rpc/Jenkinsfile
@@ -30,9 +30,10 @@ pipeline {
 
 git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $(realpath --relative-to=. $(cut -d" " -f2 .git))" > .git'
 
+CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=wcache SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/mellanox"
 make configure PLATFORM=mellanox
-make SONIC_CONFIG_BUILD_JOBS=1 ENABLE_SYNCD_RPC=y all
-make SONIC_CONFIG_BUILD_JOBS=1 target/sonic-mellanox.bin
+make SONIC_CONFIG_BUILD_JOBS=1 ENABLE_SYNCD_RPC=y $CACHE_OPTIONS all
+make SONIC_CONFIG_BUILD_JOBS=1 ENABLE_SYNCD_RPC=y $CACHE_OPTIONS target/sonic-mellanox.bin
 '''
             }
         }


### PR DESCRIPTION
So future PR build could read from the cache if already build on master branch.