### PR TITLE
[mgmt] Add canary KVM tests for sonic-mgmt repo

### DIFF
--- a/jenkins/mgmt/sonic-mgmt-canary/Jenkinsfile
+++ b/jenkins/mgmt/sonic-mgmt-canary/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
             steps {
                 wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'xterm']) {
                     lock(resource: "kvmtest_${env.NODE_NAME}") {
-                        withCredentials([sshUserPrivateKey(credentialsId: '2b6b6afe-4892-41d1-967c-d683e7773727', keyFileVariable: 'PRIVATE_KEY'), \
+                        withCredentials([sshUserPrivateKey(credentialsId: '2b6b6afe-4892-41d1-967c-d683e7773727', keyFileVariable: 'VM_USER_PRIVATE_KEY'), \
                                          usernamePassword(credentialsId: 'sonicdev-cr', usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWD')]) {
                             sh './scripts/mgmt/test.sh'
 				        }

--- a/jenkins/mgmt/sonic-mgmt-canary/Jenkinsfile
+++ b/jenkins/mgmt/sonic-mgmt-canary/Jenkinsfile
@@ -1,0 +1,53 @@
+pipeline {
+    agent { 
+        node { label 'jenkins-kvmtest-workers' } 
+    }
+
+    options {
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+    }
+
+    triggers {
+        pollSCM('@midnight')
+    }
+
+    stages {
+        stage('Prepare') {
+            steps {
+                dir('sonic-mgmt') {
+                    checkout([$class: 'GitSCM',
+                              branches: [[name: '*/master']],
+                              userRemoteConfigs: [[url: 'https://github.com/Azure/sonic-mgmt']]])
+                }
+                copyArtifacts(projectName: 'bldenv/docker-sonic-mgmt', filter: '**/docker-sonic-mgmt.gz', target: 'mgmt', flatten: true)
+                copyArtifacts(projectName: 'vs/buildimage-vs-image', filter: '**/sonic-vs.img.gz', target: 'vsimage', flatten: true)
+            }
+        }
+
+        stage('Test') {
+            steps {
+                wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'xterm']) {
+                    lock(resource: "kvmtest_${env.NODE_NAME}") {
+                        withCredentials([sshUserPrivateKey(credentialsId: '2b6b6afe-4892-41d1-967c-d683e7773727', keyFileVariable: 'PRIVATE_KEY'), \
+                                         usernamePassword(credentialsId: 'sonicdev-cr', usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWD')]) {
+                            sh './scripts/mgmt/test.sh'
+				        }
+                    }
+                }
+            }
+
+            post {
+                always {
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/results/**/*.xml')
+                    archiveArtifacts(artifacts: 'sonic-mgmt/tests/results/**, sonic-mgmt/tests/logs/**')
+                }
+            }   
+        }
+    }
+
+    post {
+        cleanup {
+            cleanWs(disableDeferredWipeout: false, deleteDirs: true, notFailBuild: true)
+        }
+    }
+}

--- a/scripts/mgmt/test.sh
+++ b/scripts/mgmt/test.sh
@@ -5,7 +5,7 @@ echo ${JOB_NAME##*/}.${BUILD_NUMBER}
 docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASSWD sonicdev-microsoft.azurecr.io:443
 docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
 
-cat $PRIVATE_KEY > pkey.txt
+cat $VM_USER_PRIVATE_KEY > pkey.txt
 
 ls -l vsimage
 

--- a/scripts/mgmt/test.sh
+++ b/scripts/mgmt/test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -xe
+
+echo ${JOB_NAME##*/}.${BUILD_NUMBER}
+
+docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASSWD sonicdev-microsoft.azurecr.io:443
+docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
+
+cat $PRIVATE_KEY > pkey.txt
+
+ls -l vsimage
+
+mkdir -p $HOME/sonic-vm/images
+cp vsimage/sonic-vs.img.gz $HOME/sonic-vm/images/
+gzip -fd $HOME/sonic-vm/images/sonic-vs.img.gz
+
+ls -l $HOME/sonic-vm/images
+
+pushd sonic-mgmt/ansible
+sed -i s:use_own_value:johnar: veos.vtb
+echo abc > password.txt
+popd
+
+docker run --rm=true -v $(pwd):/data -w /data -i sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt ./scripts/vs/buildimage-vs-image/runtest.sh


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

Description: This job runs KVM tests against the latest sonic-mgmt master branch. It is intended to measure the stability of the sonic-mgmt master branch. It also doesn't require a full rebuild of the sonic image, which should let us run the tests more often than buildimage-vs-image.