### PR TITLE
[mgmt] Add PR test for sonic-mgmt repo

### DIFF
--- a/jenkins/mgmt/sonic-mgmt-pr/Jenkinsfile
+++ b/jenkins/mgmt/sonic-mgmt-pr/Jenkinsfile
@@ -1,0 +1,50 @@
+pipeline {
+    agent { 
+        node { label 'jenkins-kvmtest-workers' } 
+    }
+
+    options {
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))
+    }
+
+    stages {
+        stage('Prepare') {
+            steps {
+                dir('sonic-mgmt') {
+                    checkout([$class: 'GitSCM',
+                              branches: [[name: '${sha1}']],
+                              userRemoteConfigs: [[url: 'https://github.com/Azure/sonic-mgmt',
+                                                   refspec: '+refs/pull/*:refs/remotes/origin/pr/*']]])
+                }
+                copyArtifacts(projectName: 'bldenv/docker-sonic-mgmt', filter: '**/docker-sonic-mgmt.gz', target: 'mgmt', flatten: true)
+                copyArtifacts(projectName: 'vs/buildimage-vs-image', filter: '**/sonic-vs.img.gz', target: 'vsimage', flatten: true)
+            }
+        }
+
+        stage('Test') {
+            steps {
+                wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'xterm']) {
+                    lock(resource: "kvmtest_${env.NODE_NAME}") {
+                        withCredentials([sshUserPrivateKey(credentialsId: '2b6b6afe-4892-41d1-967c-d683e7773727', keyFileVariable: 'VM_USER_PRIVATE_KEY'), \
+                                         usernamePassword(credentialsId: 'sonicdev-cr', usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWD')]) {
+                            sh './scripts/mgmt/test.sh'
+				        }
+                    }
+                }
+            }
+
+            post {
+                always {
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/results/**/*.xml')
+                    archiveArtifacts(artifacts: 'sonic-mgmt/tests/results/**, sonic-mgmt/tests/logs/**')
+                }
+            }   
+        }
+    }
+
+    post {
+        cleanup {
+            cleanWs(disableDeferredWipeout: false, deleteDirs: true, notFailBuild: true)
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

Description: This job runs KVM tests against PRs in the sonic-mgmt repo. It is intended to prevent breaking changes from being merged to the sonic-mgmt repo and blocking progress in sonic-mgmt and sonic-buildimage.