### PR TITLE
move build job to build worker and kvm test to kvmtest workers

### DIFF
--- a/jenkins/mgmt/sonic-mgmt-canary/Jenkinsfile
+++ b/jenkins/mgmt/sonic-mgmt-canary/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
-    agent { 
-        node { label 'jenkins-vstest-workers' } 
+    agent {
+        node { label 'jenkins-kvmtest-workers' }
     }
 
     options {
@@ -41,7 +41,7 @@ pipeline {
                     junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/results/**/*.xml')
                     archiveArtifacts(artifacts: 'sonic-mgmt/tests/results/**, sonic-mgmt/tests/logs/**')
                 }
-            }   
+            }
         }
     }
 

--- a/jenkins/mgmt/sonic-mgmt-pr/Jenkinsfile
+++ b/jenkins/mgmt/sonic-mgmt-pr/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
-    agent { 
-        node { label 'jenkins-vstest-workers' } 
+    agent {
+        node { label 'jenkins-kvmtest-workers' }
     }
 
     options {
@@ -38,7 +38,7 @@ pipeline {
                     junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/results/**/*.xml')
                     archiveArtifacts(artifacts: 'sonic-mgmt/tests/results/**, sonic-mgmt/tests/logs/**')
                 }
-            }   
+            }
         }
     }
 

--- a/jenkins/vs/buildimage-vs-all/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-all/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { node { label 'jenkins-kvmtest-workers' } }
+    agent { node { label 'jenkins-build-workers' } }
 
     options {
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))

--- a/jenkins/vs/buildimage-vs-image-201911-test/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-201911-test/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { node { label 'jenkins-vstest-workers' } }
+    agent { node { label 'jenkins-kvmtest-workers' } }
 
     parameters {
         string(name: 'PROJECT', defaultValue: 'vs/buildimage-vs-image-201911', description: 'which project to test')

--- a/jenkins/vs/buildimage-vs-image-buster/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-buster/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { node { label 'jenkins-kvmtest-workers' } }
+    agent { node { label 'jenkins-build-workers' } }
 
     options {
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))

--- a/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { node { label 'jenkins-kvmtest-workers' } }
+    agent { node { label 'jenkins-build-workers' } }
 
     options {
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))
@@ -49,7 +49,7 @@ sudo cp ../target/sonic-vs.bin /nfs/jenkins/sonic-vs-${JOB_NAME##*/}.${BUILD_NUM
         }
 
         stage('Test') {
-            agent { node { label 'jenkins-vstest-workers' } }
+            agent { node { label 'jenkins-kvmtest-workers' } }
 
             steps {
                 dir('sonic-mgmt') {

--- a/jenkins/vs/buildimage-vs-image-test/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-test/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { node { label 'jenkins-vstest-workers' } }
+    agent { node { label 'jenkins-kvmtest-workers' } }
 
     parameters {
         string(name: 'PROJECT', defaultValue: 'vs/buildimage-vs-image', description: 'which project to test')

--- a/jenkins/vs/buildimage-vs-image/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { node { label 'jenkins-kvmtest-workers' } }
+    agent { node { label 'jenkins-build-workers' } }
 
     options {
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
@@ -61,7 +61,7 @@ sudo cp ../target/sonic-vs-dbg.bin /nfs/jenkins/sonic-vs-dbg-${JOB_NAME##*/}.${B
         }
 
         stage('Test') {
-            agent { node { label 'jenkins-vstest-workers' } }
+            agent { node { label 'jenkins-kvmtest-workers' } }
 
             steps {
                 dir('sonic-mgmt') {


### PR DESCRIPTION
there will be three roles of workers
- jenkins-build-workers
- jenkins-vstest-workers
- jenkins-kvmtest-workers

The build workers are mainly for build the image.
The vstest workers are mainly for swss/sonic-utilities vs tests
The kvmtest workers are manly for sonic-mgmt kvm tests

The vstest and kvmtest can share the same physical servers. However, to help debug, we introduce two roles so that they can be separated to avoid their jobs affecting each other.