### PR TITLE
Reset repo contents before applying PR changes

### DIFF
--- a/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('sonic-buildimage') {
-                    sh 'git submodule foreach --recursive "git reset --hard"'
+                    sh 'git submodule foreach --recursive "git reset --hard" || true'
                     checkout([$class: 'GitSCM',
                           branches: [[name: '${sha1}']],
                           extensions: [[$class: 'SubmoduleOption',

--- a/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('sonic-buildimage') {
+                    sh 'git submodule foreach --recursive "git reset --hard"'
                     checkout([$class: 'GitSCM',
                           branches: [[name: '${sha1}']],
                           extensions: [[$class: 'SubmoduleOption',


### PR DESCRIPTION
Go compilation can automatically modify go.sum and go.mod files. This will remain as local change. Subsequent build will fail to checkout the PR contents to such repos. Added a reset step before PR checkout.