### PR TITLE
[workers] Deprecate "jenkins-kvm-workers" and "jenkins-workers" tags

### DIFF
--- a/jenkins/broadcom/buildimage-brcm-all-pr/Jenkinsfile
+++ b/jenkins/broadcom/buildimage-brcm-all-pr/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { node { label 'jenkins-workers' } }
+    agent { node { label 'jenkins-build-workers' } }
 
     options {
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))

--- a/jenkins/broadcom/buildimage-brcm-all-released-pr/Jenkinsfile
+++ b/jenkins/broadcom/buildimage-brcm-all-released-pr/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { node { label 'jenkins-workers' } }
+    agent { node { label 'jenkins-build-workers' } }
 
     options {
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))

--- a/jenkins/generic/buildimage-baseimage-pr/Jenkinsfile
+++ b/jenkins/generic/buildimage-baseimage-pr/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { node { label 'jenkins-workers' } }
+    agent { node { label 'jenkins-build-workers' } }
 
     options {
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))

--- a/jenkins/mellanox/buildimage-mlnx-all-pr/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-all-pr/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { node { label 'jenkins-workers' } }
+    agent { node { label 'jenkins-build-workers' } }
 
     options {
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))

--- a/jenkins/mellanox/buildimage-mlnx-all-released-pr/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-all-released-pr/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { node { label 'jenkins-workers' } }
+    agent { node { label 'jenkins-build-workers' } }
 
     options {
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))

--- a/jenkins/vs/buildimage-vs-image-201904/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-201904/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { node { label 'jenkins-kvm-workers' } }
+    agent { node { label 'jenkins-build-workers' } }
 
     options {
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))

--- a/jenkins/vs/buildimage-vs-image-201911/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-201911/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { node { label 'jenkins-kvm-workers' } }
+    agent { node { label 'jenkins-build-workers' } }
 
     options {
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))

--- a/jenkins/vs/buildimage-vs-image-released-pr/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-released-pr/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { node { label 'jenkins-kvm-workers' } }
+    agent { node { label 'jenkins-build-workers' } }
 
     options {
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))


### PR DESCRIPTION
Consolidating all of these build jobs to use the "jenkins-build-workers" tag so that we can have one unified pool of workers for all of our build jobs.

Signed-off-by: Danny Allen <daall@microsoft.com>