### PR TITLE
[mgmt] Fix sonic-mgmt pr test no result issue

### DIFF
--- a/scripts/mgmt/test.sh
+++ b/scripts/mgmt/test.sh
@@ -2,6 +2,8 @@
 
 echo ${JOB_NAME##*/}.${BUILD_NUMBER}
 
+tbname=vms-kvm-t0
+
 docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASSWD sonicdev-microsoft.azurecr.io:443
 docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
 
@@ -20,4 +22,4 @@ sed -i s:use_own_value:johnar: veos.vtb
 echo abc > password.txt
 popd
 
-docker run --rm=true -v $(pwd):/data -w /data -i sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt ./scripts/vs/buildimage-vs-image/runtest.sh
+docker run --rm=true -v $(pwd):/data -w /data -i sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt ./scripts/vs/buildimage-vs-image/runtest.sh $tbname


### PR DESCRIPTION
Fix the sonic-mgmt PR testing no test result issue.

The sonic-mgmt PR testings has no test results after #115 was merged. The `scripts\vs\buildimage-vs-image\runtest.sh` file now needs to get tbname from argument. 

**Fix:**
To fix this issue, I supplied `vms-kvm-t0` argument while calling this runtest.sh script in `scripts\mgmt\test.sh`.