### PR TITLE
[kvm] Add timeout for KVM tests

### DIFF
--- a/jenkins/mgmt/sonic-mgmt-canary/Jenkinsfile
+++ b/jenkins/mgmt/sonic-mgmt-canary/Jenkinsfile
@@ -29,7 +29,9 @@ pipeline {
                     lock(resource: "kvmtest_${env.NODE_NAME}") {
                         withCredentials([sshUserPrivateKey(credentialsId: '2b6b6afe-4892-41d1-967c-d683e7773727', keyFileVariable: 'VM_USER_PRIVATE_KEY'), \
                                          usernamePassword(credentialsId: 'sonicdev-cr', usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWD')]) {
-                            sh './scripts/vs/buildimage-vs-image/test.sh'
+                            timeout(time: 2, unit: 'HOURS') {
+                                sh './scripts/vs/buildimage-vs-image/test.sh'
+                            }
 				        }
                     }
                 }

--- a/jenkins/mgmt/sonic-mgmt-pr/Jenkinsfile
+++ b/jenkins/mgmt/sonic-mgmt-pr/Jenkinsfile
@@ -26,7 +26,9 @@ pipeline {
                     lock(resource: "kvmtest_${env.NODE_NAME}") {
                         withCredentials([sshUserPrivateKey(credentialsId: '2b6b6afe-4892-41d1-967c-d683e7773727', keyFileVariable: 'VM_USER_PRIVATE_KEY'), \
                                          usernamePassword(credentialsId: 'sonicdev-cr', usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWD')]) {
-                            sh './scripts/vs/buildimage-vs-image/test.sh'
+                            timeout(time: 2, unit: 'HOURS') {
+                                sh './scripts/vs/buildimage-vs-image/test.sh'
+                            }
 				        }
                     }
                 }

--- a/jenkins/vs/buildimage-vs-image-201911-test/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-201911-test/Jenkinsfile
@@ -54,7 +54,9 @@ pipeline {
                     lock(resource: "kvmtest_${env.NODE_NAME}") {
                         withCredentials([sshUserPrivateKey(credentialsId: '2b6b6afe-4892-41d1-967c-d683e7773727', keyFileVariable: 'VM_USER_PRIVATE_KEY'), \
                                          usernamePassword(credentialsId: 'sonicdev-cr', usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWD')]) {
-                            sh './scripts/vs/buildimage-vs-image/test.sh'
+                            timeout(time: 2, unit: 'HOURS') {
+                                sh './scripts/vs/buildimage-vs-image/test.sh'
+                            }
                         }
                     }
 				}

--- a/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
@@ -76,7 +76,10 @@ sudo cp ../target/sonic-vs.bin /nfs/jenkins/sonic-vs-${JOB_NAME##*/}.${BUILD_NUM
                         withCredentials([sshUserPrivateKey(credentialsId: '2b6b6afe-4892-41d1-967c-d683e7773727', keyFileVariable: 'VM_USER_PRIVATE_KEY'), \
                                          usernamePassword(credentialsId: 'sonicdev-cr', usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWD')]) {
                             sh './scripts/vs/buildimage-vs-image/build_kvm_image.sh'
-                            sh './scripts/vs/buildimage-vs-image/test.sh'
+                            
+                            timeout(time: 2, unit: 'HOURS') {
+                                sh './scripts/vs/buildimage-vs-image/test.sh'
+                            }
 				        }
                     }
                 }

--- a/jenkins/vs/buildimage-vs-image-test/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-test/Jenkinsfile
@@ -54,7 +54,9 @@ pipeline {
                     lock(resource: "kvmtest_${env.NODE_NAME}") {
                         withCredentials([sshUserPrivateKey(credentialsId: '2b6b6afe-4892-41d1-967c-d683e7773727', keyFileVariable: 'VM_USER_PRIVATE_KEY'), \
                                          usernamePassword(credentialsId: 'sonicdev-cr', usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWD')]) {
-                            sh './scripts/vs/buildimage-vs-image/test.sh'
+                            timeout(time: 2, unit: 'HOURS') {
+                                sh './scripts/vs/buildimage-vs-image/test.sh'
+                            }
                         }
                     }
 				}

--- a/jenkins/vs/buildimage-vs-image/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image/Jenkinsfile
@@ -89,7 +89,10 @@ sudo cp ../target/sonic-vs-dbg.bin /nfs/jenkins/sonic-vs-dbg-${JOB_NAME##*/}.${B
                         withCredentials([sshUserPrivateKey(credentialsId: '2b6b6afe-4892-41d1-967c-d683e7773727', keyFileVariable: 'VM_USER_PRIVATE_KEY'), \
                                          usernamePassword(credentialsId: 'sonicdev-cr', usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWD')]) {
                             sh './scripts/vs/buildimage-vs-image/build_kvm_image.sh'
-                            sh './scripts/vs/buildimage-vs-image/test.sh'
+
+                            timeout(time: 2, unit: 'HOURS') {
+                                sh './scripts/vs/buildimage-vs-image/test.sh'
+                            }
 				        }
                     }
                 }


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

This is a temporary fix while we work on resolving https://github.com/Azure/sonic-buildimage/issues/4822. There are certain improvements we need to make (like dumping the KVM state if the tests timeout), but this is still an improvement over waiting for someone to notice the tests are stuck before freeing up the workers.