### PR TITLE
[sonic-utilities-build/build.sh]: Add jsondiff PKG.

### DIFF
--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -18,6 +18,7 @@ sudo pip install mockredispy==2.9.3
 sudo pip install netifaces==0.10.9
 sudo pip install --upgrade setuptools
 sudo pip install pytest-runner==4.4
+sudp pip install xmltodict==0.12.0
 sudp pip install jsondiff==1.2.0
 
 sudo dpkg -i buildimage/target/debs/stretch/libyang_1.0.73_amd64.deb

--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -18,8 +18,8 @@ sudo pip install mockredispy==2.9.3
 sudo pip install netifaces==0.10.9
 sudo pip install --upgrade setuptools
 sudo pip install pytest-runner==4.4
-sudp pip install xmltodict==0.12.0
-sudp pip install jsondiff==1.2.0
+sudo pip install xmltodict==0.12.0
+sudo pip install jsondiff==1.2.0
 
 sudo dpkg -i buildimage/target/debs/stretch/libyang_1.0.73_amd64.deb
 sudo dpkg -i buildimage/target/debs/stretch/libyang-cpp_1.0.73_amd64.deb

--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -18,6 +18,7 @@ sudo pip install mockredispy==2.9.3
 sudo pip install netifaces==0.10.9
 sudo pip install --upgrade setuptools
 sudo pip install pytest-runner==4.4
+sudp pip install jsondiff==1.2.0
 
 sudo dpkg -i buildimage/target/debs/stretch/libyang_1.0.73_amd64.deb
 sudo dpkg -i buildimage/target/debs/stretch/libyang-cpp_1.0.73_amd64.deb


### PR DESCRIPTION
Add jsondiff PKG, needed for tests.

Not getting installed by specifying in the setup.py.

```
[12:11 AM] Praveen Chaudhary
    00:09:22  running pytest 00:09:22  00:09:22  Note: Bypassing https://pypi.org/simple/jsondiff/ (disallowed host; see http://bit.ly/2hrImnY for details). 00:09:22  00:09:22  Couldn't find index page for 'jsondiff' (maybe misspelled?) 00:09:22  00:09:22  Note: Bypassing https://pypi.org/simple/ (disallowed host; see http://bit.ly/2hrImnY for details). 00:09:22  00:09:22  No local packages or working download links found for jsondiff==1.2.0 00:09:22  Searching for jsondiff==1.2.0

```

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com