### PR TITLE
[sonic-utilities-build/build.sh]: Add sonic_yang_models as dep to son…

### DIFF
--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -21,6 +21,8 @@ sudo pip install pytest-runner==4.4
 sudo pip install xmltodict==0.12.0
 sudo pip install jsondiff==1.2.0
 
+sudo pip3 install buildimage/target/python-wheels/sonic_yang_models-1.0-py3-none-any.whl
+
 sudo dpkg -i buildimage/target/debs/stretch/libyang_1.0.73_amd64.deb
 sudo dpkg -i buildimage/target/debs/stretch/libyang-cpp_1.0.73_amd64.deb
 sudo dpkg -i buildimage/target/debs/stretch/python2-yang_1.0.73_amd64.deb


### PR DESCRIPTION
…ic utils.

Since we can not refer a dir in sonic-buildimage while jenkins testing of sonic-utilities.
We need to create build dependency on sonic_yang_models PKG too.
Related to that, we need this change in build.sh script.

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

Note: I wrote 'pip3 install' in different section, because it will look out of alignment with 'pip install' lines.