### PR TITLE
Fix sonic-telemetry & mgmt-framework build issues

### DIFF
--- a/jenkins/common/sonic-mgmt-common-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-mgmt-common-build-pr/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-mgmt-common',
                                                refspec: '+refs/pull/*:refs/remotes/origin/pr/*']]])
                 }
-                copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*.deb', target: 'buildimage', flatten: false)
+                copyArtifacts(projectName: 'vs/buildimage-vs-image', filter: '**/*.deb', target: 'buildimage', flatten: false)
             }
         }
 

--- a/jenkins/common/sonic-mgmt-framework-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-mgmt-framework-build-pr/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
                           branches: [[name: 'refs/heads/master']],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-mgmt-common']]])
                 }
-                copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*.deb', target: 'buildimage', flatten: false)
+                copyArtifacts(projectName: 'vs/buildimage-vs-image', filter: '**/*.deb', target: 'buildimage', flatten: false)
             }
         }
 

--- a/jenkins/common/sonic-mgmt-framework-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-mgmt-framework-build-pr/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
 
         stage('Build') {
             steps {
-                sh './scripts/common/sonic-mgmt-common-build/build.sh'
+                sh 'NO_TEST_BINS=1 ./scripts/common/sonic-mgmt-common-build/build.sh'
                 sh './scripts/common/sonic-mgmt-framework-build/build.sh'
             }
         }

--- a/jenkins/common/sonic-mgmt-framework-build/Jenkinsfile
+++ b/jenkins/common/sonic-mgmt-framework-build/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
 
         stage('Build') {
             steps {
-                sh './scripts/common/sonic-mgmt-common-build/build.sh'
+                sh 'NO_TEST_BINS=1 ./scripts/common/sonic-mgmt-common-build/build.sh'
                 sh './scripts/common/sonic-mgmt-framework-build/build.sh'
             }
         }

--- a/jenkins/common/sonic-telemetry-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-telemetry-build-pr/Jenkinsfile
@@ -10,12 +10,18 @@ pipeline {
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-telemetry',
                                                refspec: '+refs/pull/*:refs/remotes/origin/pr/*']]])
                 }
+                dir('sonic-mgmt-common') {
+                    checkout([$class: 'GitSCM',
+                          branches: [[name: 'refs/heads/master']],
+                          userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-mgmt-common']]])
+                }
                 copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*.deb', target: 'buildimage', flatten: false)
             }
         }
 
         stage('Build') {
             steps {
+                sh 'NO_TEST_BINS=1 DISTRO=stretch ./scripts/common/sonic-mgmt-common-build/build.sh'
                 sh './scripts/common/sonic-telemetry-build/build.sh'
             }
         }

--- a/jenkins/common/sonic-telemetry-build/Jenkinsfile
+++ b/jenkins/common/sonic-telemetry-build/Jenkinsfile
@@ -21,12 +21,18 @@ pipeline {
                           branches: [[name: 'refs/heads/master']],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-telemetry']]])
                 }
+                dir('sonic-mgmt-common') {
+                    checkout([$class: 'GitSCM',
+                          branches: [[name: 'refs/heads/master']],
+                          userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-mgmt-common']]])
+                }
                 copyArtifacts(projectName: '../vs/buildimage-vs-all', filter: '**/*.deb', target: 'buildimage', flatten: false)
             }
         }
 
         stage('Build') {
             steps {
+                sh 'NO_TEST_BINS=1 DISTRO=stretch ./scripts/common/sonic-mgmt-common-build/build.sh'
                 sh './scripts/common/sonic-telemetry-build/build.sh'
             }
         }

--- a/scripts/common/sonic-telemetry-build/build.sh
+++ b/scripts/common/sonic-telemetry-build/build.sh
@@ -1,30 +1,10 @@
 #!/bin/bash -ex
 
+# Build script for sonic-telemetry.
+# Assumes sonic-mgmt-common is already cloned & built.
+
 # Install HIREDIS
 sudo dpkg -i buildimage/target/debs/stretch/libhiredis*.deb
-
-# Install REDIS
-sudo apt-get install -y liblua5.1-0 lua-bitop lua-cjson
-sudo dpkg -i buildimage/target/debs/stretch/redis-tools_*.deb
-sudo dpkg -i buildimage/target/debs/stretch/redis-server_*.deb
-sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf
-sudo sed -ri 's/^unixsocketperm .../unixsocketperm 777/' /etc/redis/redis.conf
-sudo sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf
-sudo service redis-server start
-
-# Install libyang
-sudo dpkg -i buildimage/target/debs/stretch/libyang*.deb
-
-# Clone sonic-mgmt-common repository
-git clone https://github.com/Azure/sonic-mgmt-common.git
-
-# Build sonic-mgmt-common first
-
-pushd sonic-mgmt-common
-
-dpkg-buildpackage -rfakeroot -b -us -uc
-
-popd
 
 # Build sonic-telemetry
 
@@ -36,4 +16,3 @@ popd
 
 mkdir -p target
 cp *.deb target/
-


### PR DESCRIPTION
1\) Cleaned up sonic-trelemetry build script to remove all sonic-mgmt-common related steps. Jenkinsfile now includes steps to clone and build sonic-mgmt-common diretly. This solves the redis installation errors seens in telemetry PR builds.

2\) Changed sonic-mgmt-common and sonic-mgmt-framework PR builds to copy artifacts from "vs/buildimage-vs-image" build instead of "buildimage-vs-all". This is required for accessing buster debs in build scripts.