### PR TITLE
Enable Redis Unix socket for swss-common tests

### DIFF
--- a/scripts/common/sonic-swss-common-build/test.sh
+++ b/scripts/common/sonic-swss-common-build/test.sh
@@ -4,6 +4,9 @@
 sudo pip install Pympler==0.8
 sudo apt-get install -y redis-server
 sudo sed -i 's/notify-keyspace-events ""/notify-keyspace-events AKE/' /etc/redis/redis.conf
+sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf
+sudo sed -ri 's/^unixsocketperm .../unixsocketperm 777/' /etc/redis/redis.conf
+sudo sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf
 sudo service redis-server restart
 
 sudo dpkg -i libswsscommon_*.deb


### PR DESCRIPTION
A unit test for sonic-swss-common tests a function that connects to Redis via Unix socket. This PR enables Unix socket for sonic-swss-common tests.