### PR TITLE
[sonic-utilitites-build] Install sonic-py-common and archive artifacts

### DIFF
--- a/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-swss-tests/tests/tr.xml')
         }
         success {
-            archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl, sonic-swss-tests/tests/log/**')
+            archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
         }
 
         cleanup {

--- a/jenkins/common/sonic-utilities-build/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
             junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-swss-tests/tests/tr.xml')
         }
         success {
-            archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl, sonic-swss-tests/tests/log/**')
+            archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
         }
         fixed {
             slackSend(color:'#00FF00', message: "Build job back to normal: ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")

--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -14,6 +14,7 @@ sudo pip install tabulate
 sudo pip install natsort
 sudo pip install buildimage/target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl
 sudo pip install buildimage/target/python-wheels/swsssdk-2.0.1-py2-none-any.whl
+sudo pip install buildimage/target/python-wheels/sonic_py_common-1.0-py2-none-any.whl
 sudo pip install buildimage/target/python-wheels/sonic_yang_mgmt-1.0-py2-none-any.whl
 sudo pip install mockredispy==2.9.3
 sudo pip install netifaces==0.10.9
@@ -22,6 +23,7 @@ sudo pip install pytest-runner==4.4
 sudo pip install xmltodict==0.12.0
 sudo pip install jsondiff==1.2.0
 
+sudo pip3 install buildimage/target/python-wheels/sonic_py_common-1.0-py3-none-any.whl
 sudo pip3 install buildimage/target/python-wheels/sonic_yang_models-1.0-py3-none-any.whl
 
 sudo dpkg -i buildimage/target/debs/buster/libyang_1.0.73_amd64.deb


### PR DESCRIPTION
Install and archive both Python 2 and Python 3 packages to prepare for eventual transition of sonic-utilities to Python 3.