### PR TITLE
[utilities] Remove dependencies on latest swss and sairedis updates from utilities builds

### DIFF
--- a/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
                 coberturaAdapter('sonic-utilities/deb_dist/sonic-utilities-1.2/coverage.xml')
             ])
 
-            archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl, sonic-swss-tests/tests/log/**')
+            archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
         }
 
         cleanup {

--- a/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
@@ -10,9 +10,6 @@ pipeline {
                           userRemoteConfigs: [[url: 'https://github.com/Azure/sonic-utilities',
                                                refspec: '+refs/pull/*:refs/remotes/origin/pr/*']]])
                 }
-                copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'swss-common', flatten: true)
-                copyArtifacts(projectName: 'vs/sonic-swss-build', filter: '**/*.deb', target: 'swss', flatten: true)
-                copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
                 copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*', target: 'buildimage', flatten: false)
             }
         }
@@ -58,10 +55,8 @@ pipeline {
             publishCoverage(adapters: [
                 coberturaAdapter('sonic-utilities/deb_dist/sonic-utilities-1.2/coverage.xml')
             ])
-        }
 
-        success {
-            archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
+            archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl, sonic-swss-tests/tests/log/**')
         }
 
         cleanup {

--- a/jenkins/common/sonic-utilities-build/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build/Jenkinsfile
@@ -17,9 +17,6 @@ pipeline {
                           branches: [[name: '*/master']],
                           userRemoteConfigs: [[url: 'https://github.com/Azure/sonic-utilities']]])
                 }
-                copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'swss-common', flatten: true)
-                copyArtifacts(projectName: 'vs/sonic-swss-build', filter: '**/*.deb', target: 'swss', flatten: true)
-                copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
                 copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*', target: 'buildimage', flatten: false)
             }
         }
@@ -64,10 +61,8 @@ pipeline {
             publishCoverage(adapters: [
                 coberturaAdapter('sonic-utilities/deb_dist/sonic-utilities-1.2/coverage.xml')
             ])
-        }
 
-        success {
-            archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
+            archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl, sonic-swss-tests/tests/log/**')
         }
 
         fixed {

--- a/jenkins/common/sonic-utilities-build/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                 coberturaAdapter('sonic-utilities/deb_dist/sonic-utilities-1.2/coverage.xml')
             ])
 
-            archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl, sonic-swss-tests/tests/log/**')
+            archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
         }
 
         fixed {

--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -45,18 +45,6 @@ docker run --rm=true --privileged -v $(pwd):/sonic -w /sonic -i sonicdev-microso
 
 cp sonic-utilities/deb_dist/python-sonic-utilities_*.deb buildimage/target/python-debs/
 
-cd sairedis
-cp *.deb ../buildimage/target/debs/buster/
-cd ../
-
-cd swss
-cp *.deb ../buildimage/target/debs/buster/
-cd ../
-
-cd swss-common
-cp *.deb ../buildimage/target/debs/buster/
-cd ../
-
 on_exit()
 {
     sudo umount docker-sonic-vs/debs


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

Currently the builds for `sonic-utilities` fetch and install the very latest versions of `swss-common`, `sairedis`, and `swss` to run the tests.

This is problematic because if ever any of those packages are out of sync (e.g. `swss-common` receives a new update and the other two have not been rebuilt in the interim to accommodate this new change), then the `utilities` tests will experience a bunch of odd errors/failures in a very short window of time. These are difficult to debug and they block the PR pipeline for hours at a time.

We could get around this by rebuilding all of the packages for the utilities build, but seeing as the `utilities` submodule can be updated and merged into the master `build-image` independently of the other three I think this is unnecessary.

We should install the newly built `utilities` package into `docker-sonic-vs` and verify that that works. This verifies that a PR/given build of utilities is compatible with the virtual switch image and that the submodule can be updated without any issues.