### PR TITLE
[sairedis] Fix sairedis test setup

### DIFF
--- a/scripts/vs/sonic-sairedis-build/build.sh
+++ b/scripts/vs/sonic-sairedis-build/build.sh
@@ -8,6 +8,7 @@ docker run --rm=true --privileged -v $(pwd):/sonic -w /sonic -i sonicdev-microso
 
 mkdir -p scripts/vs/sonic-sairedis-build/docker-sonic-vs/debs
 cp *.deb scripts/vs/sonic-sairedis-build/docker-sonic-vs/debs
+cp common/*.deb scripts/vs/sonic-sairedis-build/docker-sonic-vs/debs
 
 docker load < buildimage/target/docker-sonic-vs.gz
 

--- a/scripts/vs/sonic-sairedis-build/build.sh
+++ b/scripts/vs/sonic-sairedis-build/build.sh
@@ -8,7 +8,7 @@ docker run --rm=true --privileged -v $(pwd):/sonic -w /sonic -i sonicdev-microso
 
 mkdir -p scripts/vs/sonic-sairedis-build/docker-sonic-vs/debs
 cp *.deb scripts/vs/sonic-sairedis-build/docker-sonic-vs/debs
-cp common/*.deb scripts/vs/sonic-sairedis-build/docker-sonic-vs/debs
+cp common/libswsscommon_1.0.0_amd64.deb scripts/vs/sonic-sairedis-build/docker-sonic-vs/debs
 
 docker load < buildimage/target/docker-sonic-vs.gz
 

--- a/scripts/vs/sonic-sairedis-build/docker-sonic-vs/Dockerfile
+++ b/scripts/vs/sonic-sairedis-build/docker-sonic-vs/Dockerfile
@@ -2,7 +2,7 @@ FROM docker-sonic-vs
 
 ADD ["debs", "/debs"]
 
-RUN dpkg -i common/libswsscommon_*.deb
+RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb
 
 RUN dpkg -i /debs/libsaimetadata_1.0.0_amd64.deb
 RUN dpkg -i /debs/libsairedis_1.0.0_amd64.deb

--- a/scripts/vs/sonic-sairedis-build/docker-sonic-vs/Dockerfile
+++ b/scripts/vs/sonic-sairedis-build/docker-sonic-vs/Dockerfile
@@ -2,6 +2,8 @@ FROM docker-sonic-vs
 
 ADD ["debs", "/debs"]
 
+RUN dpkg -i common/libswsscommon_*.deb
+
 RUN dpkg -i /debs/libsaimetadata_1.0.0_amd64.deb
 RUN dpkg -i /debs/libsairedis_1.0.0_amd64.deb
 RUN dpkg -i /debs/libsaivs_1.0.0_amd64.deb


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

sairedis and swss are compiled with the latest swsscommon, but the swsscommon debian is not installed in the container. This can cause symbol table mismatch failures as seen here:

https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/sonic-sairedis-build/1175/

This fixes that bug by installing the swsscommon used for the build into the docker-sonic-vs container.