### PR TITLE
[kvm] Use run_tests.sh script to run KVM tests

### DIFF
--- a/jenkins/mgmt/sonic-mgmt-canary/Jenkinsfile
+++ b/jenkins/mgmt/sonic-mgmt-canary/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
 
     triggers {
-        pollSCM('@midnight')
+        cron('H H/12 * * *')
     }
 
     stages {
@@ -39,8 +39,12 @@ pipeline {
 
             post {
                 always {
-                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/results/**/*.xml')
-                    archiveArtifacts(artifacts: 'sonic-mgmt/tests/results/**, sonic-mgmt/tests/logs/**, kvmdump/**, ptfdump/**')
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/logs/**/tr.xml')
+                    archiveArtifacts(artifacts: 'sonic-mgmt/tests/logs/**')
+                }
+
+                failure {
+                    archiveArtifacts(artifacts: 'kvmdump/**, ptfdump/**')
                 }
             }
         }

--- a/jenkins/mgmt/sonic-mgmt-pr/Jenkinsfile
+++ b/jenkins/mgmt/sonic-mgmt-pr/Jenkinsfile
@@ -36,8 +36,12 @@ pipeline {
 
             post {
                 always {
-                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/results/**/*.xml')
-                    archiveArtifacts(artifacts: 'sonic-mgmt/tests/results/**, sonic-mgmt/tests/logs/**, kvmdump/**, ptfdump/**')
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/logs/**/tr.xml')
+                    archiveArtifacts(artifacts: 'sonic-mgmt/tests/logs/**')
+                }
+
+                failure {
+                    archiveArtifacts(artifacts: 'kvmdump/**, ptfdump/**')
                 }
             }
         }

--- a/jenkins/vs/buildimage-vs-image-201911-test/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-201911-test/Jenkinsfile
@@ -18,7 +18,6 @@ pipeline {
         pollSCM('@midnight')
     }
 
-
     stages {
         stage('Prepare') {
             steps {
@@ -61,24 +60,21 @@ pipeline {
                     }
 				}
             }
+
+            post {
+                always {
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/logs/**/tr.xml')
+                    archiveArtifacts(artifacts: 'sonic-mgmt/tests/logs/**')
+                }
+
+                failure {
+                    archiveArtifacts(artifacts: 'kvmdump/**, ptfdump/**')
+                }
+            }
         }
 
     }
     post {
-
-        always {
-            junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/results/**/*.xml')
-            archiveArtifacts(artifacts: 'sonic-mgmt/tests/results/**, sonic-mgmt/tests/logs/**, kvmdump/**, ptfdump/**')
-        }
-
-        fixed {
-            slackSend(color:'#00FF00', message: "Build job back to normal: ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
-            office365ConnectorSend(webhookUrl: "${env.SONIC_TEAM_TEST_WEBHOOK}")
-        }
-        regression {
-            slackSend(color:'#FF0000', message: "Build job Regression: ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
-            office365ConnectorSend(webhookUrl: "${env.SONIC_TEAM_TEST_WEBHOOK}")
-        }
         cleanup {
             cleanWs(disableDeferredWipeout: false, deleteDirs: true, notFailBuild: true)
         }

--- a/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
@@ -3,7 +3,6 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))
-
     }
 
     stages {
@@ -87,18 +86,22 @@ sudo cp ../target/sonic-vs.bin /nfs/jenkins/sonic-vs-${JOB_NAME##*/}.${BUILD_NUM
 
             post {
                 always {
-                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/results/**/*.xml')
-                    archiveArtifacts(artifacts: 'target/**, sonic-mgmt/tests/results/**, sonic-mgmt/tests/logs/**, kvmdump/**, ptfdump/**')
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/logs/**/tr.xml')
+                    archiveArtifacts(artifacts: 'sonic-mgmt/tests/logs/**')
+                }
+
+                failure {
+                    archiveArtifacts(artifacts: 'kvmdump/**, ptfdump/**')
                 }
             }
         }
     }
 
     post {
-
         always {
             archiveArtifacts(artifacts: 'target/**')
         }
+
         cleanup {
             cleanWs(disableDeferredWipeout: false, deleteDirs: true, notFailBuild: true)
         }

--- a/jenkins/vs/buildimage-vs-image/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image/Jenkinsfile
@@ -100,28 +100,22 @@ sudo cp ../target/sonic-vs-dbg.bin /nfs/jenkins/sonic-vs-dbg-${JOB_NAME##*/}.${B
 
             post {
                 always {
-                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/results/**/*.xml')
-                    archiveArtifacts(artifacts: 'target/**, sonic-mgmt/tests/results/**, sonic-mgmt/tests/logs/**, kvmdump/**, ptfdump/**')
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/logs/**/tr.xml')
+                    archiveArtifacts(artifacts: 'sonic-mgmt/tests/logs/**')
+                }
+
+                failure {
+                    archiveArtifacts(artifacts: 'kvmdump/**, ptfdump/**')
                 }
             }
-
         }
     }
 
     post {
-
         always {
             archiveArtifacts(artifacts: 'target/**')
         }
 
-        fixed {
-            slackSend(color:'#00FF00', message: "Build job back to normal: ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
-            office365ConnectorSend(webhookUrl: "${env.SONIC_TEAM_WEBHOOK}")
-        }
-        regression {
-            slackSend(color:'#FF0000', message: "Build job Regression: ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
-            office365ConnectorSend(webhookUrl: "${env.SONIC_TEAM_WEBHOOK}")
-        }
         cleanup {
             cleanWs(disableDeferredWipeout: false, deleteDirs: true, notFailBuild: true)
         }

--- a/scripts/vs/buildimage-vs-image/test.sh
+++ b/scripts/vs/buildimage-vs-image/test.sh
@@ -28,7 +28,7 @@ cd sonic-mgmt/ansible
 sed -i s:use_own_value:johnar: veos_vtb
 echo abc > password.txt
 cd ../../
-docker run --rm=true -v $(pwd):/data -w /data -i sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt ./scripts/vs/buildimage-vs-image/runtest.sh $tbname
+docker run --rm=true -v $(pwd):/data -w /data -i sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt ./scripts/vs/buildimage-vs-image/runtest.sh $tbname $dut
 
 # save dut state if test fails
 if [ $? != 0 ]; then


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

We want to use `run_tests.sh` to run KVM tests in order to prevent regressions in that script in sonic-mgmt.

Previously we tried this and had to revert since the tests were finishing all the way through even when errors occurred, making it difficult to debug. Now we have added the `-q 1` option to replicate the old behavior of exiting after the first error.