### PR TITLE
[kvm] Fix log output for buildimage-vs-image-test job

### DIFF
--- a/jenkins/vs/buildimage-vs-image-test/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-test/Jenkinsfile
@@ -61,24 +61,22 @@ pipeline {
                     }
 				}
             }
+
+            post {
+                always {
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/logs/**/*.xml')
+                    archiveArtifacts(artifacts: 'sonic-mgmt/tests/logs/**')
+                }
+
+                failure {
+                    archiveArtifacts(artifacts: 'kvmdump/**, ptfdump/**')
+                }
+            }
         }
 
     }
+
     post {
-
-        always {
-            archiveArtifacts(artifacts: 'sonic-mgmt/tests/logs/**, sonic-mgmt/tests/results/**, kvmdump/**, ptfdump/**')
-            junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/results/**/*.xml')
-        }
-
-        fixed {
-            slackSend(color:'#00FF00', message: "Build job back to normal: ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
-            office365ConnectorSend(webhookUrl: "${env.SONIC_TEAM_TEST_WEBHOOK}")
-        }
-        regression {
-            slackSend(color:'#FF0000', message: "Build job Regression: ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
-            office365ConnectorSend(webhookUrl: "${env.SONIC_TEAM_TEST_WEBHOOK}")
-        }
         cleanup {
             cleanWs(disableDeferredWipeout: false, deleteDirs: true, notFailBuild: true)
         }


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

`buildimage-vs-image-test` was overlooked by #150. This PR brings the result archival up to date with #149.