### PR TITLE
[vs] Install python-swsscommon inside the DVS image

### DIFF
--- a/scripts/vs/sonic-sairedis-build/build.sh
+++ b/scripts/vs/sonic-sairedis-build/build.sh
@@ -8,7 +8,7 @@ docker run --rm=true --privileged -v $(pwd):/sonic -w /sonic -i sonicdev-microso
 
 mkdir -p scripts/vs/sonic-sairedis-build/docker-sonic-vs/debs
 cp *.deb scripts/vs/sonic-sairedis-build/docker-sonic-vs/debs
-cp common/libswsscommon_1.0.0_amd64.deb scripts/vs/sonic-sairedis-build/docker-sonic-vs/debs
+cp common/*swsscommon*_1.0.0_amd64.deb scripts/vs/sonic-sairedis-build/docker-sonic-vs/debs
 
 docker load < buildimage/target/docker-sonic-vs.gz
 

--- a/scripts/vs/sonic-sairedis-build/docker-sonic-vs/Dockerfile
+++ b/scripts/vs/sonic-sairedis-build/docker-sonic-vs/Dockerfile
@@ -3,6 +3,7 @@ FROM docker-sonic-vs
 ADD ["debs", "/debs"]
 
 RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb
+RUN dpkg -i /debs/python-swsscommon_1.0.0_amd64.deb
 
 RUN dpkg -i /debs/libsaimetadata_1.0.0_amd64.deb
 RUN dpkg -i /debs/libsairedis_1.0.0_amd64.deb

--- a/scripts/vs/sonic-swss-build/docker-sonic-vs/Dockerfile
+++ b/scripts/vs/sonic-swss-build/docker-sonic-vs/Dockerfile
@@ -5,6 +5,8 @@ ARG docker_container_name
 ADD ["debs", "/debs"]
 
 RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb
+RUN dpkg -i /debs/python-swsscommon_1.0.0_amd64.deb
+
 RUN dpkg -i /debs/libsaimetadata_1.0.0_amd64.deb
 RUN dpkg -i /debs/libsairedis_1.0.0_amd64.deb
 RUN dpkg -i /debs/libsaivs_1.0.0_amd64.deb


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

While testing https://github.com/Azure/sonic-swss-common/pull/376 we found that the warm reboot VS tests were failing.

Judy investigated further and found a bunch of errors like this:
```
Aug 18 20:25:23.337191 e77f483613a6 INFO #supervisord: restore_neighbors return importlib.import_module('_swsscommon')
Aug 18 20:25:23.337254 e77f483613a6 INFO #supervisord: restore_neighbors   File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
Aug 18 20:25:23.337283 e77f483613a6 INFO #supervisord: restore_neighbors     __import__(name)
Aug 18 20:25:23.337309 e77f483613a6 INFO #supervisord: restore_neighbors ImportError: No module named _swsscommon
```

So we looked deeper and noticed that swsscommon is installed in the VS container, but not the updated python package. We tried this out and now the tests are working as expected: https://sonic-jenkins.westus2.cloudapp.azure.com/job/common/job/jenkins_testing/job/swss-test/27/console

https://sonic-jenkins.westus2.cloudapp.azure.com/job/common/job/jenkins_testing/job/sairedis-test/15
https://sonic-jenkins.westus2.cloudapp.azure.com/job/common/job/jenkins_testing/job/swss-test/36