### PR TITLE
[vs] Fix issue of swss debian being overwritten by sairedis

### DIFF
--- a/jenkins/vs/sonic-swss-build-pr/Jenkinsfile
+++ b/jenkins/vs/sonic-swss-build-pr/Jenkinsfile
@@ -10,10 +10,10 @@ pipeline {
                               userRemoteConfigs: [[url: 'https://github.com/Azure/sonic-swss',
                                                    refspec: '+refs/pull/*:refs/remotes/origin/pr/*']]])
                 }
-                copyArtifacts(projectName: 'sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
+                copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
                 copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'common', flatten: true)
                 copyArtifacts(projectName: 'common/sonic-utilities-build', filter: '**/*.deb', target: 'utilities', flatten: true)
-                copyArtifacts(projectName: 'buildimage-vs-all', filter: '**/*.deb,**/docker-sonic-vs.gz', target: 'buildimage', flatten: false)
+                copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*.deb,**/docker-sonic-vs.gz', target: 'buildimage', flatten: false)
             }
         }
 

--- a/jenkins/vs/sonic-swss-build/Jenkinsfile
+++ b/jenkins/vs/sonic-swss-build/Jenkinsfile
@@ -17,10 +17,10 @@ pipeline {
                               branches: [[name: '*/master']],
                               userRemoteConfigs: [[url: 'https://github.com/Azure/sonic-swss']]])
                 }
-                copyArtifacts(projectName: 'sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
+                copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
                 copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'common', flatten: true)
                 copyArtifacts(projectName: 'common/sonic-utilities-build', filter: '**/*.deb', target: 'utilities', flatten: true)
-                copyArtifacts(projectName: 'buildimage-vs-all', filter: '**/*.deb,**/docker-sonic-vs.gz', target: 'buildimage', flatten: false)
+                copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*.deb,**/docker-sonic-vs.gz', target: 'buildimage', flatten: false)
             }
         }
 

--- a/scripts/vs/sonic-swss-build/build.sh
+++ b/scripts/vs/sonic-swss-build/build.sh
@@ -7,10 +7,10 @@ docker pull sonicdev-microsoft.azurecr.io:443/sonic-slave-buster-johnar:latest
 docker run --rm=true --privileged -v $(pwd):/sonic -w /sonic -i sonicdev-microsoft.azurecr.io:443/sonic-slave-buster-johnar:latest ./scripts/vs/sonic-swss-build/build_in_docker.sh
 
 mkdir -p scripts/vs/sonic-swss-build/debs
-cp *.deb scripts/vs/sonic-swss-build/debs
-cp sairedis/*.deb scripts/vs/sonic-swss-build/debs
-cp common/*.deb scripts/vs/sonic-swss-build/debs
+cp sairedis/libsai*.deb sairedis/syncd-vs_1.0.0_amd64.deb scripts/vs/sonic-swss-build/debs
+cp common/*swsscommon*.deb scripts/vs/sonic-swss-build/debs
 cp utilities/*.deb scripts/vs/sonic-swss-build/debs
+cp *.deb scripts/vs/sonic-swss-build/debs
 
 docker load < buildimage/target/docker-sonic-vs.gz
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

Fixes Azure/sonic-swss#1404

The addition of `sonic-sairedis` VS testing (https://github.com/Azure/sonic-build-tools/pull/133) led to `swss_1.0.0_amd64.deb` being added to the list of `sairedis` artifacts. Because of this change, the artifacts from `sairedis`, which is based on the latest `swss`, were overwriting the PR-built `swss` package.

This change narrows the list of artifacts being copied for the DVS build so that this does not happen again in the future. It also moves the swss install to the end.