### PR TITLE
Revert "[utilities] Remove dependencies on latest swss and sairedis updates from utilities builds"

### DIFF
--- a/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
@@ -10,6 +10,9 @@ pipeline {
                           userRemoteConfigs: [[url: 'https://github.com/Azure/sonic-utilities',
                                                refspec: '+refs/pull/*:refs/remotes/origin/pr/*']]])
                 }
+                copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'swss-common', flatten: true)
+                copyArtifacts(projectName: 'vs/sonic-swss-build', filter: '**/*.deb', target: 'swss', flatten: true)
+                copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
                 copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*', target: 'buildimage', flatten: false)
             }
         }
@@ -55,7 +58,9 @@ pipeline {
             publishCoverage(adapters: [
                 coberturaAdapter('sonic-utilities/deb_dist/sonic-utilities-1.2/coverage.xml')
             ])
+        }
 
+        success {
             archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
         }
 

--- a/jenkins/common/sonic-utilities-build/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build/Jenkinsfile
@@ -17,6 +17,9 @@ pipeline {
                           branches: [[name: '*/master']],
                           userRemoteConfigs: [[url: 'https://github.com/Azure/sonic-utilities']]])
                 }
+                copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'swss-common', flatten: true)
+                copyArtifacts(projectName: 'vs/sonic-swss-build', filter: '**/*.deb', target: 'swss', flatten: true)
+                copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
                 copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*', target: 'buildimage', flatten: false)
             }
         }
@@ -61,7 +64,9 @@ pipeline {
             publishCoverage(adapters: [
                 coberturaAdapter('sonic-utilities/deb_dist/sonic-utilities-1.2/coverage.xml')
             ])
+        }
 
+        success {
             archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
         }
 

--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -45,6 +45,18 @@ docker run --rm=true --privileged -v $(pwd):/sonic -w /sonic -i sonicdev-microso
 
 cp sonic-utilities/deb_dist/python-sonic-utilities_*.deb buildimage/target/python-debs/
 
+cd sairedis
+cp *.deb ../buildimage/target/debs/buster/
+cd ../
+
+cd swss
+cp *.deb ../buildimage/target/debs/buster/
+cd ../
+
+cd swss-common
+cp *.deb ../buildimage/target/debs/buster/
+cd ../
+
 on_exit()
 {
     sudo umount docker-sonic-vs/debs


### PR DESCRIPTION
Reverts Azure/sonic-build-tools#146

When we made this change we did not account for changes in swss leading to changes in the test behavior. This is causing failures like the ones seen here:

https://sonic-jenkins.westus2.cloudapp.azure.com/job/common/job/sonic-utilities-build/1559/
https://sonic-jenkins.westus2.cloudapp.azure.com/job/common/job/sonic-utilities-build-pr/2209/

In order to de-couple the `utilities` and `swss` builds, we need to be able to associate the tests w/ the orchagent version. This will take some time to research and implement, so I'm reverting this PR for now to un-block sonic-utilities.