### PR TITLE
[kvm] Disable LAG update test for KVM

### DIFF
--- a/scripts/vs/buildimage-vs-image/runtest.sh
+++ b/scripts/vs/buildimage-vs-image/runtest.sh
@@ -53,7 +53,6 @@ cacl/test_cacl_function.py \
 dhcp_relay/test_dhcp_relay.py \
 lldp/test_lldp.py \
 ntp/test_ntp.py \
-pc/test_po_update.py \
 route/test_default_route.py \
 snmp/test_snmp_cpu.py \
 snmp/test_snmp_interfaces.py \
@@ -64,6 +63,9 @@ syslog/test_syslog.py \
 tacacs/test_rw_user.py \
 tacacs/test_ro_user.py \
 telemetry/test_telemetry.py"
+
+# FIXME: This test has been disabled and needs to be fixed and put back in:
+# pc/test_po_update.py
 
 pushd /data/sonic-mgmt/tests
 ./run_tests.sh $PYTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

This test has become extremely flaky after a recent SWSS submodule update. It's not super clear where the problem lies, so we're going to disable this test for now and open an issue to track the image and/or test fix so that it can be added back quickly.

https://github.com/Azure/sonic-buildimage/issues/5273