### PR TITLE
Revert "Support to use the same certificate to sign image"

### DIFF
--- a/jenkins/broadcom/buildimage-brcm-all-pr/Jenkinsfile
+++ b/jenkins/broadcom/buildimage-brcm-all-pr/Jenkinsfile
@@ -6,10 +6,6 @@ pipeline {
 
     }
 
-    environment {
-        TMP_PATH=sh(script: "mktemp -d", returnStdout: true).trim()
-    }
-
     stages {
         stage('Prepare') {
             steps {
@@ -28,23 +24,17 @@ pipeline {
         }
 
         stage('Build') {
-            options {
-                azureKeyVault([[envVariable: 'PFX_FILE', name: 'sonic-signing-cert', secretType: 'Certificate']])
-            }
             steps {
                 sh '''#!/bin/bash -xe
 
 git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $(realpath --relative-to=. $(cut -d" " -f2 .git))" > .git'
 
-scripts/convert-pfx-cert-format.sh -p $PFX_FILE -k $TMP_PATH/signing.key -c $TMP_PATH/signing.cert -a $TMP_PATH/ca.cert
-SONIC_OVERRIDE_BUILD_VARS="SIGNING_KEY=/tmp/certs/signing.key SIGNING_CERT=/tmp/certs/signing.cert CA_CERT=/tmp/certs/ca.cert"
-DOCKER_BUILDER_MOUNT="$(pwd):/sonic -v $TMP_PATH:/tmp/certs"
 CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=rcache SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/broadcom"
 make configure PLATFORM=broadcom
 
 make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS target/sonic-broadcom.bin
 make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS target/sonic-broadcom.raw
-make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS ENABLE_IMAGE_SIGNATURE=y SONIC_OVERRIDE_BUILD_VARS="${SONIC_OVERRIDE_BUILD_VARS}" DOCKER_BUILDER_MOUNT="${DOCKER_BUILDER_MOUNT}" target/sonic-aboot-broadcom.swi
+make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS ENABLE_IMAGE_SIGNATURE=y target/sonic-aboot-broadcom.swi
 '''
             }
         }
@@ -57,9 +47,6 @@ make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS ENABLE_IMAGE_SIGNATURE=y SONIC_OVE
         }
         success {
             archiveArtifacts(artifacts: 'target/**')
-        }
-        cleanup {
-            sh "[ -d $TMP_PATH ] && rm -rf $TMP_PATH"
         }
     }
 }

--- a/jenkins/broadcom/buildimage-brcm-all-released-pr/Jenkinsfile
+++ b/jenkins/broadcom/buildimage-brcm-all-released-pr/Jenkinsfile
@@ -5,9 +5,6 @@ pipeline {
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))
 
     }
-    environment {
-        TMP_PATH=sh(script: "mktemp -d", returnStdout: true).trim()
-    }
 
     stages {
         stage('Prepare') {
@@ -27,9 +24,6 @@ pipeline {
         }
 
         stage('Build') {
-            options {
-                azureKeyVault([[envVariable: 'PFX_FILE', name: 'sonic-signing-cert', secretType: 'Certificate']])
-            }
             steps {
                 sh '''#!/bin/bash -xe
 
@@ -37,12 +31,9 @@ git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $(realpath --rel
 
 make configure PLATFORM=broadcom
 
-scripts/convert-pfx-cert-format.sh -p $PFX_FILE -k $TMP_PATH/signing.key -c $TMP_PATH/signing.cert -a $TMP_PATH/ca.cert
-SONIC_OVERRIDE_BUILD_VARS="SIGNING_KEY=/tmp/certs/signing.key SIGNING_CERT=/tmp/certs/signing.cert CA_CERT=/tmp/certs/ca.cert"
-DOCKER_BUILDER_MOUNT="$(pwd):/sonic -v $TMP_PATH:/tmp/certs"
 make SONIC_CONFIG_BUILD_JOBS=1 target/sonic-broadcom.bin
 make SONIC_CONFIG_BUILD_JOBS=1 target/sonic-broadcom.raw
-make SONIC_CONFIG_BUILD_JOBS=1 ENABLE_IMAGE_SIGNATURE=y SONIC_OVERRIDE_BUILD_VARS="${SONIC_OVERRIDE_BUILD_VARS}" DOCKER_BUILDER_MOUNT="${DOCKER_BUILDER_MOUNT}" target/sonic-aboot-broadcom.swi
+make SONIC_CONFIG_BUILD_JOBS=1 ENABLE_IMAGE_SIGNATURE=y target/sonic-aboot-broadcom.swi
 '''
             }
         }
@@ -52,9 +43,6 @@ make SONIC_CONFIG_BUILD_JOBS=1 ENABLE_IMAGE_SIGNATURE=y SONIC_OVERRIDE_BUILD_VAR
 
         success {
             archiveArtifacts(artifacts: 'target/**')
-        }
-        cleanup {
-            sh "[ -d $TMP_PATH ] && rm -rf $TMP_PATH"
         }
     }
 }

--- a/jenkins/broadcom/buildimage-brcm-all/Jenkinsfile
+++ b/jenkins/broadcom/buildimage-brcm-all/Jenkinsfile
@@ -7,7 +7,6 @@ pipeline {
 
     environment {
         SONIC_TEAM_WEBHOOK = credentials('public-jenkins-builder')
-        TMP_PATH=sh(script: "mktemp -d", returnStdout: true).trim()
     }
 
     triggers {
@@ -33,23 +32,17 @@ pipeline {
         }
 
         stage('Build') {
-            options {
-                azureKeyVault([[envVariable: 'PFX_FILE', name: 'sonic-signing-cert', secretType: 'Certificate']])
-            }
             steps {
                 sh '''#!/bin/bash -xe
 
 git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $(realpath --relative-to=. $(cut -d" " -f2 .git))" > .git'
 
-scripts/convert-pfx-cert-format.sh -p $PFX_FILE -k $TMP_PATH/signing.key -c $TMP_PATH/signing.cert -a $TMP_PATH/ca.cert
-SONIC_OVERRIDE_BUILD_VARS="SIGNING_KEY=/tmp/certs/signing.key SIGNING_CERT=/tmp/certs/signing.cert CA_CERT=/tmp/certs/ca.cert"
-DOCKER_BUILDER_MOUNT="$(pwd):/sonic -v $TMP_PATH:/tmp/certs"
 CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=wcache SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/broadcom"
 make configure PLATFORM=broadcom
 make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS INSTALL_DEBUG_TOOLS=y target/sonic-broadcom.bin
 mv target/sonic-broadcom.bin target/sonic-broadcom-dbg.bin
 make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS target/sonic-broadcom.bin
-make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS ENABLE_IMAGE_SIGNATURE=y SONIC_OVERRIDE_BUILD_VARS="${SONIC_OVERRIDE_BUILD_VARS}" DOCKER_BUILDER_MOUNT="${DOCKER_BUILDER_MOUNT}" target/sonic-aboot-broadcom.swi
+make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS ENABLE_IMAGE_SIGNATURE=y target/sonic-aboot-broadcom.swi
 make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS target/sonic-broadcom.raw
 make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS target/docker-syncd-brcm-rpc.gz target/docker-ptf-brcm.gz target/docker-saiserver-brcm.gz
 '''
@@ -72,7 +65,6 @@ make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS target/docker-syncd-brcm-rpc.gz ta
         }
         cleanup {
             cleanWs(disableDeferredWipeout: false, deleteDirs: true, notFailBuild: true)
-            sh "[ -d $TMP_PATH ] && rm -rf $TMP_PATH"
         }
     }
 }

--- a/jenkins/broadcom/buildimage-brcm-buster/Jenkinsfile
+++ b/jenkins/broadcom/buildimage-brcm-buster/Jenkinsfile
@@ -7,7 +7,6 @@ pipeline {
 
     environment {
         SONIC_TEAM_WEBHOOK = credentials('public-jenkins-builder')
-        TMP_PATH=sh(script: "mktemp -d", returnStdout: true).trim()
     }
 
     triggers {
@@ -33,22 +32,15 @@ pipeline {
         }
 
         stage('Build') {
-            options {
-                azureKeyVault([[envVariable: 'PFX_FILE', name: 'sonic-signing-cert', secretType: 'Certificate']])
-            }
             steps {
                 sh '''#!/bin/bash -xe
 
 git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $(realpath --relative-to=. $(cut -d" " -f2 .git))" > .git'
 
 make configure PLATFORM=broadcom
-
-scripts/convert-pfx-cert-format.sh -p $PFX_FILE -k $TMP_PATH/signing.key -c $TMP_PATH/signing.cert -a $TMP_PATH/ca.cert
-SONIC_OVERRIDE_BUILD_VARS="SIGNING_KEY=/tmp/certs/signing.key SIGNING_CERT=/tmp/certs/signing.cert CA_CERT=/tmp/certs/ca.cert"
-DOCKER_BUILDER_MOUNT="$(pwd):/sonic -v $TMP_PATH:/tmp/certs"
 CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=rwcache SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/broadcom"
 make SONIC_CONFIG_BUILD_JOBS=1 INSTALL_DEBUG_TOOLS=y $CACHE_OPTIONS target/sonic-broadcom.bin
-# make SONIC_CONFIG_BUILD_JOBS=1 ENABLE_IMAGE_SIGNATURE=y SONIC_OVERRIDE_BUILD_VARS="${SONIC_OVERRIDE_BUILD_VARS}" DOCKER_BUILDER_MOUNT="${DOCKER_BUILDER_MOUNT}" target/sonic-aboot-broadcom.swi
+# make SONIC_CONFIG_BUILD_JOBS=1 ENABLE_IMAGE_SIGNATURE=y target/sonic-aboot-broadcom.swi
 # make SONIC_CONFIG_BUILD_JOBS=1 target/sonic-broadcom.raw
 # make SONIC_CONFIG_BUILD_JOBS=1 target/docker-syncd-brcm-rpc.gz target/docker-ptf-brcm.gz target/docker-saiserver-brcm.gz
 '''
@@ -71,7 +63,6 @@ make SONIC_CONFIG_BUILD_JOBS=1 INSTALL_DEBUG_TOOLS=y $CACHE_OPTIONS target/sonic
         }
         cleanup {
             cleanWs(disableDeferredWipeout: false, deleteDirs: true, notFailBuild: true)
-            sh "[ -d $TMP_PATH ] && rm -rf $TMP_PATH"
         }
     }
 }


### PR DESCRIPTION
Reverts Azure/sonic-build-tools#140
This commit modified `jenkins/broadcom/buildimage-brcm-all-released-pr/Jenkinsfile`, and if a buildimage PR targeting 201811 branch, that  job will fail because the file `convert-pfx-cert-format.sh` does not exists on https://github.com/Azure/sonic-buildimage/tree/201811 branch.

We need to revisit this commit and make it general to all branches.