### PR TITLE
Added the test case for Port Channel cleanup into runtest.sh

### DIFF
--- a/scripts/vs/buildimage-vs-image/runtest.sh
+++ b/scripts/vs/buildimage-vs-image/runtest.sh
@@ -53,6 +53,7 @@ cacl/test_cacl_function.py \
 dhcp_relay/test_dhcp_relay.py \
 lldp/test_lldp.py \
 ntp/test_ntp.py \
+pc/test_po_cleanup.py \
 route/test_default_route.py \
 snmp/test_snmp_cpu.py \
 snmp/test_snmp_interfaces.py \
@@ -62,8 +63,7 @@ snmp/test_snmp_queue.py \
 syslog/test_syslog.py \
 tacacs/test_rw_user.py \
 tacacs/test_ro_user.py \
-telemetry/test_telemetry.py \
-pc/test_po_cleanup.py"
+telemetry/test_telemetry.py"
 
 # FIXME: This test has been disabled and needs to be fixed and put back in:
 # pc/test_po_update.py

--- a/scripts/vs/buildimage-vs-image/runtest.sh
+++ b/scripts/vs/buildimage-vs-image/runtest.sh
@@ -62,7 +62,8 @@ snmp/test_snmp_queue.py \
 syslog/test_syslog.py \
 tacacs/test_rw_user.py \
 tacacs/test_ro_user.py \
-telemetry/test_telemetry.py"
+telemetry/test_telemetry.py \
+pc/test_po_cleanup.py"
 
 # FIXME: This test has been disabled and needs to be fixed and put back in:
 # pc/test_po_update.py


### PR DESCRIPTION
Test make sure cleanup happens of Port-channel Kernel devices.
This test case track the fixes done by PR:
Azure/sonic-swss#1407
Azure/sonic-swss#1159

Verified on 201911 KVM Image test case is passed

johnar@6b57928a7072:/data/Networking-acs-sonic-mgmt/tests$ !252
sudo py.test --inventory "veos.vtb" --host-pattern vlab-01 --module-path "../ansible/library/" --testbed vms-kvm-t0 --testbed_file "vtestbed.csv"  -vvv pc/test_po_cleanup.py --skip_sanity
=============================================================================================== test session starts ===============================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, repeat-0.8.0, forked-1.1.3
collected 1 item

pc/test_po_cleanup.py::test_po_cleanup [[APASSED                                                     [100%]

====================================== 1 passed in 174.22 seconds =======================================

Updated on master with result:

Platform: x86_64-kvm_x86_64-r0
HwSKU: Force10-S6000
ASIC: vs
Serial Number: 000000
Uptime: 00:22:06 up 5 min,  1 user,  load average: 0.35, 0.46, 0.22

Docker images:
REPOSITORY                    TAG                   IMAGE ID            SIZE
docker-syncd-vs               latest                3d9ea8ec98b0        362MB
docker-syncd-vs               master.476-8d285b46   3d9ea8ec98b0        362MB
docker-teamd                  latest                39d361a54835        386MB
docker-teamd                  master.476-8d285b46   39d361a54835        386MB
docker-nat                    latest                c4f0345fe40c        389MB
docker-nat                    master.476-8d285b46   c4f0345fe40c        389MB

johnar@6b57928a7072:/data/Networking-acs-sonic-mgmt/tests$ sudo py.test --inventory "veos.vtb" --host-pattern vlab-01 --module-path "../ansible/library/" --testbed vms-kvm-t0 --testbed_file "vtestbed.csv"  -vvv
pc/test_po_cleanup.py --skip_sanity
========================================== test session starts ==========================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, repeat-0.8.0, forked-1.1.3
collected 1 item

pc/test_po_cleanup.py::test_po_cleanup ^A^[[APASSED                                                                                                                                                               [100%]




Signed-off-by: Abhishek Dosi <abdosi@microsoft.com>