### PR TITLE
Install libzmq in sonic-sairedis-build

### DIFF
--- a/scripts/vs/sonic-sairedis-build/docker_build_script.sh
+++ b/scripts/vs/sonic-sairedis-build/docker_build_script.sh
@@ -3,6 +3,9 @@
 # Install HIREDIS
 sudo apt-get install -y libhiredis0.14 libhiredis-dev
 
+# Install libzmq
+sudo apt-get install -y libzmq-dev
+
 # Install libnl3
 sudo dpkg -i buildimage/target/debs/buster/libnl-3-200_*.deb
 sudo dpkg -i buildimage/target/debs/buster/libnl-3-dev_*.deb


### PR DESCRIPTION
Required for sonic-sairedis compilaton, since new communication channel was added between syncd/sairedis using libzmq