### PR TITLE
Add libboost for sonic-sairedis-script

### DIFF
--- a/scripts/vs/sonic-sairedis-build/docker_build_script.sh
+++ b/scripts/vs/sonic-sairedis-build/docker_build_script.sh
@@ -15,6 +15,9 @@ sudo dpkg -i buildimage/target/debs/buster/libnl-nf-3-dev_*.deb
 sudo dpkg -i buildimage/target/debs/buster/libnl-cli-3-200_*.deb
 sudo dpkg -i buildimage/target/debs/buster/libnl-cli-3-dev_*.deb
 
+# Instal libboost
+sudo apt-get install -y libboost-all-dev
+
 # Install common library
 sudo dpkg -i common/libswsscommon_*.deb
 sudo dpkg -i common/libswsscommon-dev_*.deb


### PR DESCRIPTION
Since libzmq does not use actual shared memory to communicate between processes, we will implement shared memory model on single cpu by our own using libboost in sonic-sairedis repo    