### PR TITLE
[sonic-utilities] Build as Python wheel instead of Debian package

### DIFF
--- a/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
@@ -50,18 +50,18 @@ pipeline {
                 allowMissing: false,
                 alwaysLinkToLastBuild: false,
                 keepAll: true,
-                reportDir: 'sonic-utilities/deb_dist/sonic-utilities-1.2/htmlcov',
+                reportDir: 'sonic-utilities/htmlcov',
                 reportFiles: 'index.html',
                 reportName: 'RCov Report'
             ])
 
             publishCoverage(adapters: [
-                coberturaAdapter('sonic-utilities/deb_dist/sonic-utilities-1.2/coverage.xml')
+                coberturaAdapter('sonic-utilities/coverage.xml')
             ])
         }
 
         success {
-            archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
+            archiveArtifacts(artifacts: 'sonic-utilities/dist/sonic_utilities-1.2-py2-none-any.whl,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
         }
 
         cleanup {

--- a/jenkins/common/sonic-utilities-build/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build/Jenkinsfile
@@ -56,18 +56,18 @@ pipeline {
                 allowMissing: false,
                 alwaysLinkToLastBuild: false,
                 keepAll: true,
-                reportDir: 'sonic-utilities/deb_dist/sonic-utilities-1.2/htmlcov',
+                reportDir: 'sonic-utilities/htmlcov',
                 reportFiles: 'index.html',
                 reportName: 'RCov Report'
             ])
 
             publishCoverage(adapters: [
-                coberturaAdapter('sonic-utilities/deb_dist/sonic-utilities-1.2/coverage.xml')
+                coberturaAdapter('sonic-utilities/coverage.xml')
             ])
         }
 
         success {
-            archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
+            archiveArtifacts(artifacts: 'sonic-utilities/dist/sonic_utilities-1.2-py2-none-any.whl,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
         }
 
         fixed {

--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -31,8 +31,8 @@ sudo dpkg -i buildimage/target/debs/buster/python2-yang_1.0.73_amd64.deb
 
 cd sonic-utilities
 
-# Test building the Debian package
-sudo python setup.py --command-packages=stdeb.command bdist_deb
+# Test building the Python wheel
+sudo python setup.py bdist_wheel
 
 EOF
 
@@ -43,7 +43,7 @@ docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASSWD sonicdev-microsoft.azurec
 docker pull sonicdev-microsoft.azurecr.io:443/sonic-slave-buster-johnar:latest
 docker run --rm=true --privileged -v $(pwd):/sonic -w /sonic -i sonicdev-microsoft.azurecr.io:443/sonic-slave-buster-johnar ./build_sonic_utilities.sh
 
-cp sonic-utilities/deb_dist/python-sonic-utilities_*.deb buildimage/target/python-debs/
+cp sonic-utilities/dist/sonic_utilities-*.whl buildimage/target/python-wheels/
 
 cd sairedis
 cp *.deb ../buildimage/target/debs/buster/


### PR DESCRIPTION
Build sonic-utilities as a Python wheel instead of a Debian package to support https://github.com/Azure/sonic-utilities/pull/1122