### PR TITLE
[sonic-utilities] Explicitly run unit tests in build script

### DIFF
--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -31,7 +31,10 @@ sudo dpkg -i buildimage/target/debs/buster/python2-yang_1.0.73_amd64.deb
 
 cd sonic-utilities
 
-# Test building the Python wheel
+# Run unit tests
+sudo python setup.py test
+
+# Build the Python wheel
 sudo python setup.py bdist_wheel
 
 EOF


### PR DESCRIPTION
When we were building the sonic-utilities package as a Debian package, the `python setup.py --command-packages=stdeb.commandbdist_deb` operation would automatically run the unit tests before build. Now that we've changed to building a Python wheel, the `python setup.py bdist_wheel` operation does not automatically run the unit tests.

In this patch, we explictly run the unit tests using `sudo python setup.py test` before building the wheel.