### PR TITLE
[sonic-utilities] No longer mount target/python-debs/ directory

### DIFF
--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -72,11 +72,9 @@ trap on_exit EXIT
 cd buildimage/platform/vs
 mkdir -p docker-sonic-vs/debs
 mkdir -p docker-sonic-vs/files
-mkdir -p docker-sonic-vs/python-debs
 mkdir -p docker-sonic-vs/python-wheels
 sudo mount --bind ../../target/debs/buster docker-sonic-vs/debs
 sudo mount --bind ../../target/files/buster docker-sonic-vs/files
-sudo mount --bind ../../target/python-debs docker-sonic-vs/python-debs
 sudo mount --bind ../../target/python-wheels docker-sonic-vs/python-wheels
 docker load < ../../target/docker-config-engine-buster.gz
 docker build --no-cache -t docker-sonic-vs:${JOB_NAME##*/}.${BUILD_NUMBER} docker-sonic-vs

--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -6,10 +6,10 @@ cat <<EOF > build_sonic_utilities.sh
 #!/bin/bash -xe
 ls -lrt
 
+# TODO: Clean this section up. Remove packages which get installed implicitly by sonic-utilities/setup.py
 sudo apt-get install python-m2crypto
 sudo apt-get -y purge python-click
 sudo pip install "click>=7.0"
-sudo pip install click-default-group==1.2
 sudo pip install tabulate
 sudo pip install natsort
 sudo pip install buildimage/target/python-wheels/swsssdk-2.0.1-py2-none-any.whl


### PR DESCRIPTION
Now that sonic-utilities is built as a wheel, the target/python-debs/ directory of the VS build is empty and therefore does not get archived which caused the `mount` command to fail.

Also no longer install click-default-group, as sonic-utilities no longer depends on it.