### PR TITLE
[sonic-utilities] Don't umount target/python-debs/ directory, as it's no longer mounted

### DIFF
--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -64,7 +64,6 @@ on_exit()
 {
     sudo umount docker-sonic-vs/debs
     sudo umount docker-sonic-vs/files
-    sudo umount docker-sonic-vs/python-debs
     sudo umount docker-sonic-vs/python-wheels
 }
 trap on_exit EXIT


### PR DESCRIPTION
In PR https://github.com/Azure/sonic-build-tools/pull/167, we no longer mount the target/python-debs/ directory as it doesn't get archived now that it's empty. We also shouldn't try to unmount the directory.