### PR TITLE
[swss] Remove references to deprecated sonic-utilites debian package

### DIFF
--- a/jenkins/vs/sonic-swss-build-pr/Jenkinsfile
+++ b/jenkins/vs/sonic-swss-build-pr/Jenkinsfile
@@ -12,7 +12,6 @@ pipeline {
                 }
                 copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
                 copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'common', flatten: true)
-                copyArtifacts(projectName: 'common/sonic-utilities-build', filter: '**/*.deb', target: 'utilities', flatten: true)
                 copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*.deb,**/docker-sonic-vs.gz', target: 'buildimage', flatten: false)
             }
         }

--- a/jenkins/vs/sonic-swss-build/Jenkinsfile
+++ b/jenkins/vs/sonic-swss-build/Jenkinsfile
@@ -19,7 +19,6 @@ pipeline {
                 }
                 copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
                 copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'common', flatten: true)
-                copyArtifacts(projectName: 'common/sonic-utilities-build', filter: '**/*.deb', target: 'utilities', flatten: true)
                 copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*.deb,**/docker-sonic-vs.gz', target: 'buildimage', flatten: false)
             }
         }

--- a/scripts/vs/sonic-swss-build/build.sh
+++ b/scripts/vs/sonic-swss-build/build.sh
@@ -9,7 +9,6 @@ docker run --rm=true --privileged -v $(pwd):/sonic -w /sonic -i sonicdev-microso
 mkdir -p scripts/vs/sonic-swss-build/debs
 cp sairedis/libsai*.deb sairedis/syncd-vs_1.0.0_amd64.deb scripts/vs/sonic-swss-build/debs
 cp common/*swsscommon*.deb scripts/vs/sonic-swss-build/debs
-cp utilities/*.deb scripts/vs/sonic-swss-build/debs
 cp *.deb scripts/vs/sonic-swss-build/debs
 
 docker load < buildimage/target/docker-sonic-vs.gz


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

The sonic-utilities build no longer creates a `.deb` package, so the reference needs to be updated in `swss`. Since this package isn't currently used anywhere in `swss`, I have removed it altogether.