### PR TITLE
Configure db config file for mgmt-framework and mgmt-common PR tests

### DIFF
--- a/scripts/common/sonic-mgmt-common-build/test.sh
+++ b/scripts/common/sonic-mgmt-common-build/test.sh
@@ -8,6 +8,9 @@
 STATUS=0
 DEBDIR=$(realpath sonic-mgmt-common/debian/sonic-mgmt-common)
 
+[[ -f sonic-mgmt-common/tools/test/database_config.json ]] && \
+    export DB_CONFIG_PATH=${PWD}/sonic-mgmt-common/tools/test/database_config.json
+
 # Run CVL tests
 
 pushd sonic-mgmt-common/build/tests/cvl

--- a/scripts/common/sonic-mgmt-framework-build/test.sh
+++ b/scripts/common/sonic-mgmt-framework-build/test.sh
@@ -7,6 +7,9 @@
 STATUS=0
 DEBDIR=$(realpath sonic-mgmt-common/debian/sonic-mgmt-common)
 
+[[ -f sonic-mgmt-common/tools/test/database_config.json ]] && \
+    export DB_CONFIG_PATH=${PWD}/sonic-mgmt-common/tools/test/database_config.json
+
 pushd sonic-mgmt-framework/build/tests/rest
 
 export CVL_SCHEMA_PATH=${DEBDIR}/usr/sbin/schema


### PR DESCRIPTION
Multi db enhancements in sonic-mgmt-common requires database_config.json
file for running tests. Updated mgmt-common and mgmt-framework PR test
runner scripts to setup the a dummy database_config.json file.
It includes only 1 local redis instance, running on standard port 6379.