### PR TITLE
[brcm] Add ENABLE_SYNCD_RPC flag for BRCM syncd-rpc build

### DIFF
--- a/jenkins/broadcom/buildimage-brcm-all/Jenkinsfile
+++ b/jenkins/broadcom/buildimage-brcm-all/Jenkinsfile
@@ -44,7 +44,7 @@ mv target/sonic-broadcom.bin target/sonic-broadcom-dbg.bin
 make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS target/sonic-broadcom.bin
 make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS ENABLE_IMAGE_SIGNATURE=y target/sonic-aboot-broadcom.swi
 make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS target/sonic-broadcom.raw
-make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS target/docker-syncd-brcm-rpc.gz
+ENABLE_SYNCD_RPC=y make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS target/docker-syncd-brcm-rpc.gz
 # make SONIC_CONFIG_BUILD_JOBS=1 $CACHE_OPTIONS target/docker-ptf-brcm.gz target/docker-saiserver-brcm.gz
 '''
             }


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

If this flag isn't set, then the SYNCD_RPC build variable never gets set (see: https://github.com/Azure/sonic-buildimage/blob/6088bd59ded064f392b7618872e1306057b955e1/rules/syncd.mk#L15).

As a result, syncd never gets added to the list of deps for the syncd-rpc docker here: https://github.com/Azure/sonic-buildimage/blob/master/platform/broadcom/docker-syncd-brcm-rpc.mk

Because of this, the syncd-rpc docker that is currently being built on Jenkins is missing syncd entirely, causing it to crash during startup because it can't find/run any of the syncd binaries.