### PR TITLE
[sonic-utilities] Install swsscommon deb packages before unit test

### DIFF
--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -19,6 +19,7 @@ sudo dpkg -i buildimage/target/debs/buster/libyang-cpp_1.0.73_amd64.deb
 sudo dpkg -i buildimage/target/debs/buster/python2-yang_1.0.73_amd64.deb
 sudo dpkg -i buildimage/target/debs/buster/libswsscommon_1.0.0_amd64.deb
 sudo dpkg -i buildimage/target/debs/buster/python-swsscommon_1.0.0_amd64.deb
+sudo dpkg -i buildimage/target/debs/buster/python3-swsscommon_1.0.0_amd64.deb
 
 cd sonic-utilities
 

--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -17,6 +17,8 @@ sudo pip3 install buildimage/target/python-wheels/sonic_yang_models-1.0-py3-none
 sudo dpkg -i buildimage/target/debs/buster/libyang_1.0.73_amd64.deb
 sudo dpkg -i buildimage/target/debs/buster/libyang-cpp_1.0.73_amd64.deb
 sudo dpkg -i buildimage/target/debs/buster/python2-yang_1.0.73_amd64.deb
+sudo dpkg -i buildimage/target/debs/buster/libswsscommon_1.0.0_amd64.deb
+sudo dpkg -i buildimage/target/debs/buster/python-swsscommon_1.0.0_amd64.deb
 
 cd sonic-utilities
 


### PR DESCRIPTION
sonic-utilities will depend on sonic-swss-common