### PR TITLE
[sonic-utilities] Test and build Python 3 package, but don't fail build yet

### DIFF
--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -7,16 +7,22 @@ cat <<EOF > build_sonic_utilities.sh
 ls -lrt
 
 sudo pip2 install --upgrade setuptools
+sudo pip3 install --upgrade setuptools
 sudo pip2 install buildimage/target/python-wheels/swsssdk-2.0.1-py2-none-any.whl
+sudo pip3 install buildimage/target/python-wheels/swsssdk-2.0.1-py3-none-any.whl
 sudo pip2 install buildimage/target/python-wheels/sonic_py_common-1.0-py2-none-any.whl
+sudo pip3 install buildimage/target/python-wheels/sonic_py_common-1.0-py3-none-any.whl
 sudo pip2 install buildimage/target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl
+sudo pip3 install buildimage/target/python-wheels/sonic_config_engine-1.0-py3-none-any.whl
 sudo pip2 install buildimage/target/python-wheels/sonic_yang_mgmt-1.0-py2-none-any.whl
+sudo pip3 install buildimage/target/python-wheels/sonic_yang_mgmt-1.0-py3-none-any.whl
 
 sudo pip3 install buildimage/target/python-wheels/sonic_yang_models-1.0-py3-none-any.whl
 
 sudo dpkg -i buildimage/target/debs/buster/libyang_1.0.73_amd64.deb
 sudo dpkg -i buildimage/target/debs/buster/libyang-cpp_1.0.73_amd64.deb
 sudo dpkg -i buildimage/target/debs/buster/python2-yang_1.0.73_amd64.deb
+sudo dpkg -i buildimage/target/debs/buster/python3-yang_1.0.73_amd64.deb
 
 # Below is required for swsscommon
 sudo dpkg -i buildimage/target/debs/buster/{libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb,libhiredis0.14_*.deb}
@@ -25,6 +31,12 @@ sudo dpkg -i buildimage/target/debs/buster/python-swsscommon_1.0.0_amd64.deb
 sudo dpkg -i buildimage/target/debs/buster/python3-swsscommon_1.0.0_amd64.deb
 
 cd sonic-utilities
+
+# Run unit tests
+sudo python3 setup.py test || true
+
+# Build the Python wheel
+sudo python3 setup.py bdist_wheel || true
 
 # Run unit tests
 sudo python2 setup.py test


### PR DESCRIPTION
In preparation for moving sonic-utilities to Python 3, in the sonic-utilities build script, we install all the Python 3 dependencies and attempt to test and build the Python 3 version of the package. This will ensure we can see the Python 3 build/test success status in the PR check build output. However, we will not fail the build job yet if the Python 3 test or build fails.