### PR TITLE
[sonic-utilities] Support PR check builds for 201911 branch

### DIFF
--- a/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
@@ -10,17 +10,26 @@ pipeline {
                           userRemoteConfigs: [[url: 'https://github.com/Azure/sonic-utilities',
                                                refspec: '+refs/pull/*:refs/remotes/origin/pr/*']]])
                 }
-                copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'swss-common', flatten: true)
-                copyArtifacts(projectName: 'vs/sonic-swss-build', filter: '**/*.deb', target: 'swss', flatten: true)
-                copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
-                copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*', target: 'buildimage', flatten: false)
+
+                if ('${ghprbTargetBranch}' == '201911') {
+                    copyArtifacts(projectName: 'vs/buildimage-vs-201911', filter: '**/*', target: 'buildimage', flatten: false)
+                } else {
+                    copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'swss-common', flatten: true)
+                    copyArtifacts(projectName: 'vs/sonic-swss-build', filter: '**/*.deb', target: 'swss', flatten: true)
+                    copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
+                    copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*', target: 'buildimage', flatten: false)
+                }
             }
         }
 
         stage('Build') {
             steps {
                 withCredentials([usernamePassword(credentialsId: 'sonicdev-cr', usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWD')]) {
-                    sh './scripts/common/sonic-utilities-build/build.sh'
+                    if ('${ghprbTargetBranch}' == '201911') {
+                        sh './scripts/common/sonic-utilities-build/build_201911.sh'
+                    } else {
+                        sh './scripts/common/sonic-utilities-build/build.sh'
+                    }
                 }
             }
         }
@@ -36,7 +45,10 @@ pipeline {
         stage('Test') {
             steps {
                 wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'xterm']) {
-                    sh './scripts/common/sonic-utilities-build/test.sh'
+                    /* We will only run SwSS tests against master branch PRs */
+                    if ('${ghprbTargetBranch}' == 'master') {
+                        sh './scripts/common/sonic-utilities-build/test.sh'
+                    }
                 }
             }
         }

--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -34,7 +34,7 @@ EOF
 
 chmod 755 build_sonic_utilities.sh
 
-# Build sonic-utilities and copy resulting Debian package
+# Build sonic-utilities and copy resulting Python wheel
 docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASSWD sonicdev-microsoft.azurecr.io:443
 docker pull sonicdev-microsoft.azurecr.io:443/sonic-slave-buster-johnar:latest
 docker run --rm=true --privileged -v $(pwd):/sonic -w /sonic -i sonicdev-microsoft.azurecr.io:443/sonic-slave-buster-johnar ./build_sonic_utilities.sh

--- a/scripts/common/sonic-utilities-build/build_201911.sh
+++ b/scripts/common/sonic-utilities-build/build_201911.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -xe
+
+echo ${JOB_NAME##*/}.${BUILD_NUMBER}
+
+cat <<EOF > build_sonic_utilities.sh
+#!/bin/bash -xe
+ls -lrt
+
+sudo apt-get install python-m2crypto
+sudo apt-get -y purge python-click
+sudo pip install "click>=7.0"
+sudo pip install click-default-group==1.2
+sudo pip install tabulate
+sudo pip install natsort
+sudo pip install buildimage/target/python-wheels/swsssdk-2.0.1-py2-none-any.whl
+sudo pip install buildimage/target/python-wheels/sonic_py_common-1.0-py2-none-any.whl
+sudo pip install buildimage/target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl
+sudo pip install buildimage/target/python-wheels/sonic_yang_mgmt-1.0-py2-none-any.whl
+sudo pip install mockredispy==2.9.3
+sudo pip install netifaces==0.10.9
+sudo pip install --upgrade setuptools
+sudo pip install pytest-runner==4.4
+sudo pip install xmltodict==0.12.0
+sudo pip install jsondiff==1.2.0
+
+sudo dpkg -i buildimage/target/debs/stretch/libyang_1.0.73_amd64.deb
+sudo dpkg -i buildimage/target/debs/stretch/libyang-cpp_1.0.73_amd64.deb
+sudo dpkg -i buildimage/target/debs/stretch/python2-yang_1.0.73_amd64.deb
+
+cd sonic-utilities
+
+# Test building the Debian package
+sudo python setup.py --command-packages=stdeb.command bdist_deb
+
+EOF
+
+chmod 755 build_sonic_utilities.sh
+
+# Build sonic-utilities and copy resulting Debian package
+docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASSWD sonicdev-microsoft.azurecr.io:443
+docker pull sonicdev-microsoft.azurecr.io:443/sonic-slave-stretch-johnar:latest
+docker run --rm=true --privileged -v $(pwd):/sonic -w /sonic -i sonicdev-microsoft.azurecr.io:443/sonic-slave-stretch-johnar ./build_sonic_utilities.sh
+
+cp sonic-utilities/deb_dist/python-sonic-utilities_*.deb buildimage/target/python-debs/


### PR DESCRIPTION
If the target branch is "201911", we will copy artifacts from the latest buildimage-vs-201911 build, then build the sonic-utilities Python 2 Debian package. We will not run SwSS tests against the 201911 branch PR, only against the master branch.