### PR TITLE
[sonic-utilities] Enclose conditional statements in a 'script' block

### DIFF
--- a/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
@@ -11,13 +11,15 @@ pipeline {
                                                refspec: '+refs/pull/*:refs/remotes/origin/pr/*']]])
                 }
 
-                if ('${ghprbTargetBranch}' == '201911') {
-                    copyArtifacts(projectName: 'vs/buildimage-vs-201911', filter: '**/*', target: 'buildimage', flatten: false)
-                } else {
-                    copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'swss-common', flatten: true)
-                    copyArtifacts(projectName: 'vs/sonic-swss-build', filter: '**/*.deb', target: 'swss', flatten: true)
-                    copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
-                    copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*', target: 'buildimage', flatten: false)
+                script {
+                    if ('${ghprbTargetBranch}' == '201911') {
+                        copyArtifacts(projectName: 'vs/buildimage-vs-201911', filter: '**/*', target: 'buildimage', flatten: false)
+                    } else {
+                        copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'swss-common', flatten: true)
+                        copyArtifacts(projectName: 'vs/sonic-swss-build', filter: '**/*.deb', target: 'swss', flatten: true)
+                        copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
+                        copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*', target: 'buildimage', flatten: false)
+                    }
                 }
             }
         }
@@ -25,10 +27,12 @@ pipeline {
         stage('Build') {
             steps {
                 withCredentials([usernamePassword(credentialsId: 'sonicdev-cr', usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWD')]) {
-                    if ('${ghprbTargetBranch}' == '201911') {
-                        sh './scripts/common/sonic-utilities-build/build_201911.sh'
-                    } else {
-                        sh './scripts/common/sonic-utilities-build/build.sh'
+                    script {
+                        if ('${ghprbTargetBranch}' == '201911') {
+                            sh './scripts/common/sonic-utilities-build/build_201911.sh'
+                        } else {
+                            sh './scripts/common/sonic-utilities-build/build.sh'
+                        }
                     }
                 }
             }
@@ -45,9 +49,11 @@ pipeline {
         stage('Test') {
             steps {
                 wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'xterm']) {
-                    /* We will only run SwSS tests against master branch PRs */
-                    if ('${ghprbTargetBranch}' == 'master') {
-                        sh './scripts/common/sonic-utilities-build/test.sh'
+                    script {
+                        /* We will only run SwSS tests against master branch PRs */
+                        if ('${ghprbTargetBranch}' == 'master') {
+                            sh './scripts/common/sonic-utilities-build/test.sh'
+                        }
                     }
                 }
             }


### PR DESCRIPTION
It appears that in declarative pipelines, conditional statements must be enclosed within `script` blocks, otherwise we will see errors like the following:

```
14:10:20  org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
14:10:20  WorkflowScript: 14: Expected a step @ line 14, column 17.
14:10:20                     if ('${ghprbTargetBranch}' == '201911') {
14:10:20                     ^
```