### PR TITLE
[sonic-utilities] Remove quotes and ${} from around environment variable in conditions

### DIFF
--- a/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
                 }
 
                 script {
-                    if ('${env.ghprbTargetBranch}' == '201911') {
+                    if (env.ghprbTargetBranch == '201911') {
                         copyArtifacts(projectName: 'vs/buildimage-vs-201911', filter: '**/*', target: 'buildimage', flatten: false)
                     } else {
                         copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'swss-common', flatten: true)
@@ -28,7 +28,7 @@ pipeline {
             steps {
                 withCredentials([usernamePassword(credentialsId: 'sonicdev-cr', usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWD')]) {
                     script {
-                        if ('${env.ghprbTargetBranch}' == '201911') {
+                        if (env.ghprbTargetBranch == '201911') {
                             sh './scripts/common/sonic-utilities-build/build_201911.sh'
                         } else {
                             sh './scripts/common/sonic-utilities-build/build.sh'
@@ -51,7 +51,7 @@ pipeline {
                 wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'xterm']) {
                     script {
                         /* We will only run SwSS tests against master branch PRs */
-                        if ('${env.ghprbTargetBranch}' == 'master') {
+                        if (env.ghprbTargetBranch == 'master') {
                             sh './scripts/common/sonic-utilities-build/test.sh'
                         }
                     }

--- a/scripts/common/sonic-utilities-build/build_201911.sh
+++ b/scripts/common/sonic-utilities-build/build_201911.sh
@@ -8,6 +8,7 @@ ls -lrt
 
 sudo apt-get install python-m2crypto
 sudo apt-get -y purge python-click
+sudo pip install --upgrade setuptools
 sudo pip install "click>=7.0"
 sudo pip install click-default-group==1.2
 sudo pip install tabulate
@@ -15,17 +16,11 @@ sudo pip install natsort
 sudo pip install buildimage/target/python-wheels/swsssdk-2.0.1-py2-none-any.whl
 sudo pip install buildimage/target/python-wheels/sonic_py_common-1.0-py2-none-any.whl
 sudo pip install buildimage/target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl
-sudo pip install buildimage/target/python-wheels/sonic_yang_mgmt-1.0-py2-none-any.whl
 sudo pip install mockredispy==2.9.3
 sudo pip install netifaces==0.10.9
-sudo pip install --upgrade setuptools
 sudo pip install pytest-runner==4.4
 sudo pip install xmltodict==0.12.0
 sudo pip install jsondiff==1.2.0
-
-sudo dpkg -i buildimage/target/debs/stretch/libyang_1.0.73_amd64.deb
-sudo dpkg -i buildimage/target/debs/stretch/libyang-cpp_1.0.73_amd64.deb
-sudo dpkg -i buildimage/target/debs/stretch/python2-yang_1.0.73_amd64.deb
 
 cd sonic-utilities
 


### PR DESCRIPTION
Remove quotes and `${}` from around environment variable in conditions. `${}` is only needed when referencing the variable in things like an `echo` statement.

Also, don't install packages which aren't relevant in 201911 branch