### PR TITLE
[sonic-utilities-build-pr] Do not attempt to publish Pytest coverage for 201911 branch

### DIFF
--- a/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
@@ -64,22 +64,33 @@ pipeline {
         always {
             junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-swss-tests/tests/tr.xml')
 
-            publishHTML(target: [
-                allowMissing: false,
-                alwaysLinkToLastBuild: false,
-                keepAll: true,
-                reportDir: 'sonic-utilities/htmlcov',
-                reportFiles: 'index.html',
-                reportName: 'RCov Report'
-            ])
+            script {
+                /* 201911 branch does not generate Pytest coverage report */
+                if (env.ghprbTargetBranch != '201911') {
+                    publishHTML(target: [
+                        allowMissing: false,
+                        alwaysLinkToLastBuild: false,
+                        keepAll: true,
+                        reportDir: 'sonic-utilities/htmlcov',
+                        reportFiles: 'index.html',
+                        reportName: 'RCov Report'
+                    ])
 
-            publishCoverage(adapters: [
-                coberturaAdapter('sonic-utilities/coverage.xml')
-            ])
+                    publishCoverage(adapters: [
+                        coberturaAdapter('sonic-utilities/coverage.xml')
+                    ])
+                }
+            }
         }
 
         success {
-            archiveArtifacts(artifacts: 'sonic-utilities/dist/sonic_utilities-1.2-py2-none-any.whl,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
+            script {
+                if (env.ghprbTargetBranch == '201911') {
+                    archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
+                } else {
+                    archiveArtifacts(artifacts: 'sonic-utilities/dist/sonic_utilities-1.2-py2-none-any.whl,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
+                }
+            }
         }
 
         cleanup {


### PR DESCRIPTION
- 201911 branch does not have Pytest coverage support, so there are no coverage results to publish
- Also add 201911-branch-specific archiving logic