### PR TITLE
[sonic-utilities-build] Explicitly install 'mock' package and use Python 2 for 201911 branch

### DIFF
--- a/scripts/common/sonic-utilities-build/build_201911.sh
+++ b/scripts/common/sonic-utilities-build/build_201911.sh
@@ -16,7 +16,7 @@ sudo pip2 install natsort
 sudo pip2 install buildimage/target/python-wheels/swsssdk-2.0.1-py2-none-any.whl
 sudo pip2 install buildimage/target/python-wheels/sonic_py_common-1.0-py2-none-any.whl
 sudo pip2 install buildimage/target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl
-sudo pip2 install mock==4.0.2
+sudo pip2 install mock==3.0.5
 sudo pip2 install mockredispy==2.9.3
 sudo pip2 install netifaces==0.10.9
 sudo pip2 install pytest-runner==4.4

--- a/scripts/common/sonic-utilities-build/build_201911.sh
+++ b/scripts/common/sonic-utilities-build/build_201911.sh
@@ -8,24 +8,25 @@ ls -lrt
 
 sudo apt-get install python-m2crypto
 sudo apt-get -y purge python-click
-sudo pip install --upgrade setuptools
-sudo pip install "click>=7.0"
-sudo pip install click-default-group==1.2
-sudo pip install tabulate
-sudo pip install natsort
-sudo pip install buildimage/target/python-wheels/swsssdk-2.0.1-py2-none-any.whl
-sudo pip install buildimage/target/python-wheels/sonic_py_common-1.0-py2-none-any.whl
-sudo pip install buildimage/target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl
-sudo pip install mockredispy==2.9.3
-sudo pip install netifaces==0.10.9
-sudo pip install pytest-runner==4.4
-sudo pip install xmltodict==0.12.0
-sudo pip install jsondiff==1.2.0
+sudo pip2 install --upgrade setuptools
+sudo pip2 install "click>=7.0"
+sudo pip2 install click-default-group==1.2
+sudo pip2 install tabulate
+sudo pip2 install natsort
+sudo pip2 install buildimage/target/python-wheels/swsssdk-2.0.1-py2-none-any.whl
+sudo pip2 install buildimage/target/python-wheels/sonic_py_common-1.0-py2-none-any.whl
+sudo pip2 install buildimage/target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl
+sudo pip2 install mock==4.0.2
+sudo pip2 install mockredispy==2.9.3
+sudo pip2 install netifaces==0.10.9
+sudo pip2 install pytest-runner==4.4
+sudo pip2 install xmltodict==0.12.0
+sudo pip2 install jsondiff==1.2.0
 
 cd sonic-utilities
 
 # Test building the Debian package
-sudo python setup.py --command-packages=stdeb.command bdist_deb
+sudo python2 setup.py --command-packages=stdeb.command bdist_deb
 
 EOF
 


### PR DESCRIPTION
Something changed recently which caused the sonic-utilities 201911 PR build to fail to install the `mock` package from PyPI implicitly. Here, we install version 3.0.5 (the latest version available for Python 2) of the package explicitly before building the sonic-utilities package.

Also, explicitly call `pip2` and `python2` instead of `pip` and `python` just to ensure the proper versions are used.