### PR TITLE
[vs-image-pr] Fix submodule checkout for VS image tests

### DIFF
--- a/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
@@ -63,7 +63,7 @@ sudo cp ../target/sonic-vs.bin /nfs/jenkins/sonic-vs-${JOB_NAME##*/}.${BUILD_NUM
                           extensions: [[$class: 'SubmoduleOption',
                                         disableSubmodules: false,
                                         parentCredentials: false,
-                                        recursiveSubmodules: false,
+                                        recursiveSubmodules: true,
                                         reference: '',
                                         trackingSubmodules: false]],
                           userRemoteConfigs: [[url: 'http://github.com/Azure/sonic-buildimage',


### PR DESCRIPTION
We've started noticing strange errors when we try to checkout submodules during the Test stage of this Jenkins job, like this:

09:01:33  From https://github.com/Azure/sonic-telemetry
09:01:33     e54f9ca..d3336d1  master     -> origin/master
09:01:33  fatal: remote error: upload-pack: not our ref ca07e68bb8bafc6e5aab341c5c8a35605044a7d3
09:01:33  fatal: the remote end hung up unexpectedly

We've noticed these for sairedis and telemetry. The Build stage is working consistently, and the only difference we can see between this stage and the Test stage is this recursiveSubmodules flag. This PR sets that flag for the Test stage as well in order to mitigate the impact on our PR builds.

Signed-off-by: Danny Allen <daall@microsoft.com>