### PR TITLE
Invalidate docker build cache when apt-get update

### DIFF
--- a/jenkins/common/sonic-swss-common-build-ubuntu/Dockerfile
+++ b/jenkins/common/sonic-swss-common-build-ubuntu/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:bionic
 
-RUN apt-get update
+RUN apt-get update  # 20210106 invalidate docker build cache
 RUN apt-get install -y make libtool m4 autoconf dh-exec debhelper cmake pkg-config \
                        libhiredis-dev libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libnl-nf-3-dev swig3.0 \
                        libpython2.7-dev libgtest-dev libboost-dev


### PR DESCRIPTION
Otherwise it may reuse cache
```
13:03:28  Step 1/10 : FROM ubuntu:bionic
13:03:28   ---> 2c047404e52d
13:03:28  Step 2/10 : RUN apt-get update
13:03:28   ---> Using cache
13:03:28   ---> cd848a921aa8
```

This cache may be outdated.