### PR TITLE
Add arm build lock to avoid parallel arm builds on one Jenkins node

### DIFF
--- a/jenkins/centec-arm64/buildimage-centec-arm64-202012/Jenkinsfile
+++ b/jenkins/centec-arm64/buildimage-centec-arm64-202012/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
 
         stage('Build') {
             steps {
+              lock(resource: "arm_build_${env.NODE_NAME}") {
                 sh '''#!/bin/bash -xe
                       git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $(realpath --relative-to=. $(cut -d" " -f2 .git))" > .git'
                       export DOCKER_DATA_ROOT_FOR_MULTIARCH=/data/march/docker
@@ -46,7 +47,8 @@ pipeline {
                           pid=`sudo cat dockerfs/var/run/docker.pid` ; sudo kill $pid
                       fi
                       sudo rm -rf ${DOCKER_DATA_ROOT_FOR_MULTIARCH}
-                      '''
+                   '''
+               }
             }
         }
 

--- a/jenkins/centec-arm64/buildimage-centec-arm64-all/Jenkinsfile
+++ b/jenkins/centec-arm64/buildimage-centec-arm64-all/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
 
         stage('Build') {
             steps {
+              lock(resource: "arm_build_${env.NODE_NAME}") {
                 sh '''#!/bin/bash -xe
                       git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $(realpath --relative-to=. $(cut -d" " -f2 .git))" > .git'
                       export DOCKER_DATA_ROOT_FOR_MULTIARCH=/data/march/docker
@@ -46,7 +47,8 @@ pipeline {
                           pid=`sudo cat dockerfs/var/run/docker.pid` ; sudo kill $pid
                       fi
                       sudo rm -rf ${DOCKER_DATA_ROOT_FOR_MULTIARCH}
-                      '''
+                   '''
+              }
             }
         }
 

--- a/jenkins/marvell-armhf/buildimage-mrvl-armhf-202012/Jenkinsfile
+++ b/jenkins/marvell-armhf/buildimage-mrvl-armhf-202012/Jenkinsfile
@@ -34,6 +34,7 @@ pipeline {
 
         stage('Build') {
             steps {
+              lock(resource: "arm_build_${env.NODE_NAME}") {
                 sh '''#!/bin/bash -xe
 
 git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $(realpath --relative-to=. $(cut -d" " -f2 .git))" > .git'
@@ -53,6 +54,7 @@ if sudo [ -f dockerfs/var/run/docker.pid ] ; then
 fi
 sudo rm -rf ${DOCKER_DATA_ROOT_FOR_MULTIARCH}
 '''
+              }
             }
         }
 

--- a/jenkins/marvell-armhf/buildimage-mrvl-armhf-all/Jenkinsfile
+++ b/jenkins/marvell-armhf/buildimage-mrvl-armhf-all/Jenkinsfile
@@ -34,6 +34,7 @@ pipeline {
 
         stage('Build') {
             steps {
+              lock(resource: "arm_build_${env.NODE_NAME}") {
                 sh '''#!/bin/bash -xe
 
 git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $(realpath --relative-to=. $(cut -d" " -f2 .git))" > .git'
@@ -53,6 +54,7 @@ if sudo [ -f dockerfs/var/run/docker.pid ] ; then
 fi
 sudo rm -rf ${DOCKER_DATA_ROOT_FOR_MULTIARCH}
 '''
+              }
             }
         }
 


### PR DESCRIPTION
Add arm build lock to avoid concurrent arm build job on one Jenkins node.