### PR TITLE
Resolve libyang dependency for mgmt builds

### DIFF
--- a/scripts/common/sonic-mgmt-common-build/build.sh
+++ b/scripts/common/sonic-mgmt-common-build/build.sh
@@ -14,7 +14,7 @@ sudo sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf
 sudo service redis-server start
 
 # LIBYANG
-sudo dpkg -i buildimage/target/debs/${DISTRO}/libyang*.deb
+sudo dpkg -i buildimage/target/debs/${DISTRO}/libyang*1.0.73*.deb
 
 
 pushd sonic-mgmt-common

--- a/scripts/common/sonic-mgmt-framework-build/build.sh
+++ b/scripts/common/sonic-mgmt-framework-build/build.sh
@@ -12,7 +12,7 @@ sudo sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf
 sudo service redis-server start
 
 # LIBYANG
-sudo dpkg -i buildimage/target/debs/${DISTRO}/libyang*.deb
+sudo dpkg -i buildimage/target/debs/${DISTRO}/libyang*1.0.73*.deb
 
 # Install from "requirement" files in sonic-mgmt-framework/tools/test directory.
 pushd sonic-mgmt-framework/tools/test

--- a/scripts/common/sonic-telemetry-build/build.sh
+++ b/scripts/common/sonic-telemetry-build/build.sh
@@ -11,7 +11,7 @@ sudo sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf
 sudo service redis-server start
 
 # Install libyang
-sudo dpkg -i buildimage/target/debs/buster/libyang*.deb
+sudo dpkg -i buildimage/target/debs/buster/libyang*1.0.73*.deb
 
 # Build sonic-mgmt-common first
 


### PR DESCRIPTION
Second version of libyang (v1.0.184) has been introduced recently.
Changed PR build scripts of sonic-mgmt-common, sonic-mgmt-framework and
sonic-telemetry repos to explicitly pick old libyang 1.0.73.