### PR TITLE
Revert "Exclude some large files in archiveArtifacts"

### DIFF
--- a/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
@@ -87,7 +87,7 @@ sudo cp ../target/sonic-vs.bin /nfs/jenkins/sonic-vs-${JOB_NAME##*/}.${BUILD_NUM
             post {
                 always {
                     junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/logs/**/*.xml')
-                    archiveArtifacts(artifacts: 'target/**, sonic-mgmt/tests/logs/**', excludes: 'target/sonic-vs.bin, target/sonic-vs.vhdx')
+                    archiveArtifacts(artifacts: 'target/**, sonic-mgmt/tests/logs/**')
                 }
 
                 failure {
@@ -98,6 +98,10 @@ sudo cp ../target/sonic-vs.bin /nfs/jenkins/sonic-vs-${JOB_NAME##*/}.${BUILD_NUM
     }
 
     post {
+        always {
+            archiveArtifacts(artifacts: 'target/**')
+        }
+
         cleanup {
             cleanWs(disableDeferredWipeout: false, deleteDirs: true, notFailBuild: true)
         }

--- a/jenkins/vs/buildimage-vs-image/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image/Jenkinsfile
@@ -101,7 +101,7 @@ sudo cp ../target/sonic-vs-dbg.bin /nfs/jenkins/sonic-vs-dbg-${JOB_NAME##*/}.${B
             post {
                 always {
                     junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'sonic-mgmt/tests/logs/**/*.xml')
-                    archiveArtifacts(artifacts: 'target/**, sonic-mgmt/tests/logs/**', excludes: 'target/sonic-vs.bin, target/sonic-vs.vhdx')
+                    archiveArtifacts(artifacts: 'target/**, sonic-mgmt/tests/logs/**')
                 }
 
                 failure {
@@ -112,6 +112,10 @@ sudo cp ../target/sonic-vs-dbg.bin /nfs/jenkins/sonic-vs-dbg-${JOB_NAME##*/}.${B
     }
 
     post {
+        always {
+            archiveArtifacts(artifacts: 'target/**')
+        }
+
         cleanup {
             cleanWs(disableDeferredWipeout: false, deleteDirs: true, notFailBuild: true)
         }


### PR DESCRIPTION
Reverts Azure/sonic-build-tools#215

This commit exclude much more files than expected.