### PR TITLE
[sonic-utilities-build] add sonic-platform-common install for sonic-utilities build

### DIFF
--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -10,6 +10,7 @@ sudo pip3 install --upgrade setuptools
 sudo pip3 install buildimage/target/python-wheels/swsssdk-2.0.1-py3-none-any.whl
 sudo pip3 install buildimage/target/python-wheels/sonic_py_common-1.0-py3-none-any.whl
 sudo pip3 install buildimage/target/python-wheels/sonic_config_engine-1.0-py3-none-any.whl
+sudo pip3 install buildimage/target/python-wheels/sonic_platform_common-1.0-py3-none-any.whl
 sudo pip3 install buildimage/target/python-wheels/sonic_yang_mgmt-1.0-py3-none-any.whl
 sudo pip3 install buildimage/target/python-wheels/sonic_yang_models-1.0-py3-none-any.whl
 


### PR DESCRIPTION
since sonic-utilities requires  sonic_y_cable package for muxcable cli, sonic-platform-common install is required
for sonic-utilities build, for test cases to be passed in sonic-utilities. 

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>