### PR TITLE
[sonic-utilities] Install sonic-platform-common package before build

### DIFF
--- a/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
                         copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'swss-common', flatten: true)
                         copyArtifacts(projectName: 'vs/sonic-swss-build', filter: '**/*.deb', target: 'swss', flatten: true)
                         copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
-                        copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*', target: 'buildimage', flatten: false)
+                        copyArtifacts(projectName: 'vs/buildimage-vs-image', filter: '**/*', target: 'buildimage', flatten: false)
                     }
                 }
             }
@@ -88,7 +88,7 @@ pipeline {
                 if (env.ghprbTargetBranch == '201911') {
                     archiveArtifacts(artifacts: 'sonic-utilities/deb_dist/python-sonic-utilities_1.2-1_all.deb,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
                 } else {
-                    archiveArtifacts(artifacts: 'sonic-utilities/dist/sonic_utilities-1.2-py2-none-any.whl,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
+                    archiveArtifacts(artifacts: 'sonic-utilities/dist/sonic_utilities-1.2-py3-none-any.whl,wheels/sonic_config_engine-1.0-py3-none-any.whl,wheels/swsssdk-2.0.1-py3-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl,wheels/sonic_platform_common-1.0-py3-none-any.whl,sonic-swss-tests/tests/log/**')
                 }
             }
         }

--- a/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build-pr/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
                         copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'swss-common', flatten: true)
                         copyArtifacts(projectName: 'vs/sonic-swss-build', filter: '**/*.deb', target: 'swss', flatten: true)
                         copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
-                        copyArtifacts(projectName: 'vs/buildimage-vs-image', filter: '**/*', target: 'buildimage', flatten: false)
+                        copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*', target: 'buildimage', flatten: false)
                     }
                 }
             }

--- a/jenkins/common/sonic-utilities-build/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
                 copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'swss-common', flatten: true)
                 copyArtifacts(projectName: 'vs/sonic-swss-build', filter: '**/*.deb', target: 'swss', flatten: true)
                 copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
-                copyArtifacts(projectName: 'vs/buildimage-vs-image', filter: '**/*', target: 'buildimage', flatten: false)
+                copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*', target: 'buildimage', flatten: false)
             }
         }
 

--- a/jenkins/common/sonic-utilities-build/Jenkinsfile
+++ b/jenkins/common/sonic-utilities-build/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
                 copyArtifacts(projectName: 'common/sonic-swss-common-build', filter: '**/*.deb', target: 'swss-common', flatten: true)
                 copyArtifacts(projectName: 'vs/sonic-swss-build', filter: '**/*.deb', target: 'swss', flatten: true)
                 copyArtifacts(projectName: 'vs/sonic-sairedis-build', filter: '**/*.deb', target: 'sairedis', flatten: true)
-                copyArtifacts(projectName: 'vs/buildimage-vs-all', filter: '**/*', target: 'buildimage', flatten: false)
+                copyArtifacts(projectName: 'vs/buildimage-vs-image', filter: '**/*', target: 'buildimage', flatten: false)
             }
         }
 
@@ -67,7 +67,7 @@ pipeline {
         }
 
         success {
-            archiveArtifacts(artifacts: 'sonic-utilities/dist/sonic_utilities-1.2-py2-none-any.whl,wheels/sonic_config_engine-1.0-py2-none-any.whl,wheels/swsssdk-2.0.1-py2-none-any.whl,wheels/sonic_py_common-1.0-py2-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl, sonic-swss-tests/tests/log/**')
+            archiveArtifacts(artifacts: 'sonic-utilities/dist/sonic_utilities-1.2-py3-none-any.whl,wheels/sonic_config_engine-1.0-py3-none-any.whl,wheels/swsssdk-2.0.1-py3-none-any.whl,wheels/sonic_py_common-1.0-py3-none-any.whl,wheels/sonic_platform_common-1.0-py3-none-any.whl,sonic-swss-tests/tests/log/**')
         }
 
         fixed {

--- a/scripts/common/sonic-utilities-build/build.sh
+++ b/scripts/common/sonic-utilities-build/build.sh
@@ -10,6 +10,7 @@ sudo pip3 install --upgrade setuptools
 sudo pip3 install buildimage/target/python-wheels/swsssdk-2.0.1-py3-none-any.whl
 sudo pip3 install buildimage/target/python-wheels/sonic_py_common-1.0-py3-none-any.whl
 sudo pip3 install buildimage/target/python-wheels/sonic_config_engine-1.0-py3-none-any.whl
+sudo pip3 install buildimage/target/python-wheels/sonic_platform_common-1.0-py3-none-any.whl
 sudo pip3 install buildimage/target/python-wheels/sonic_yang_mgmt-1.0-py3-none-any.whl
 sudo pip3 install buildimage/target/python-wheels/sonic_yang_models-1.0-py3-none-any.whl
 


### PR DESCRIPTION
Recent changes to sonic-utilities requires importing sonic_y_cable package for muxcable cli. sonic_y_cable is part of the sonic-platform-common package, so we need to install sonic-platform-common before building sonic-utilities.

Also, change archiveArtifacts for master branch builds to archive Python 3 versions of the packages, as we no longer build a Python 2 sonic-utilities package.