### PR TITLE
[mrvl-armhf] prevent recent build failures

### DIFF
--- a/jenkins/marvell-armhf/buildimage-mrvl-armhf-all/Jenkinsfile
+++ b/jenkins/marvell-armhf/buildimage-mrvl-armhf-all/Jenkinsfile
@@ -34,11 +34,18 @@ pipeline {
 
         stage('Build') {
             steps {
+              script {
+                System.setProperty("org.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL", "86400");
+              }
               lock(resource: "arm_build_${env.NODE_NAME}") {
                 sh '''#!/bin/bash -xe
 
 git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $(realpath --relative-to=. $(cut -d" " -f2 .git))" > .git'
 export DOCKER_DATA_ROOT_FOR_MULTIARCH=/data/march/docker
+#
+# Cleanup disk space before getting started
+sudo rm -rf ${DOCKER_DATA_ROOT_FOR_MULTIARCH}
+#
 make configure PLATFORM=marvell-armhf PLATFORM_ARCH=armhf
 #
 # Skip debug build for now until build time improvements can be made


### PR DESCRIPTION
Many mrvl-armhf Jenkins builds have been failing due to running out of storage
space or excessive filesystem lag. This commit attempts to remedy that by
providing the following.

  - Before starting the Build stage clean up any storage space consumed by a
    previous failed build on the same Jenkins node
  - Increase the max filesystem lag property to avoid failures due to
    excessive lag.