### PR TITLE
[multi_asic]: Modify contents of asic.conf file to build image

### DIFF
--- a/jenkins/vs/buildimage-multiasic-vs-image-201911/Jenkinsfile
+++ b/jenkins/vs/buildimage-multiasic-vs-image-201911/Jenkinsfile
@@ -38,7 +38,7 @@ git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $(realpath --rel
 
 make configure PLATFORM=vs
 
-sudo bash -c "echo "NUM_ASIC=6" > ./device/virtual/x86_64-kvm_x86_64-r0/asic.conf"
+sudo bash -c "echo -e "NUM_ASIC=4\nDEV_ID_ASIC_0=0\nDEV_ID_ASIC_1=1\nDEV_ID_ASIC_2=2\nDEV_ID_ASIC_3=3" > ./device/virtual/x86_64-kvm_x86_64-r0/asic.conf"
 
 sudo bash -c "echo 1 > /proc/sys/vm/compact_memory"
 


### PR DESCRIPTION
Add change to include asic device IDs in asic.conf before building image.
Change number of asics to 4 as the test multi-asic vs image.

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>