### PR TITLE
Adjust log history queue length

### DIFF
--- a/jenkins/barefoot/buildimage-bf-201904/Jenkinsfile
+++ b/jenkins/barefoot/buildimage-bf-201904/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
 
     }
 

--- a/jenkins/barefoot/buildimage-bf-201911/Jenkinsfile
+++ b/jenkins/barefoot/buildimage-bf-201911/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/barefoot/buildimage-bf-202006/Jenkinsfile
+++ b/jenkins/barefoot/buildimage-bf-202006/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/barefoot/buildimage-bf-202012/Jenkinsfile
+++ b/jenkins/barefoot/buildimage-bf-202012/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/barefoot/buildimage-bf-all/Jenkinsfile
+++ b/jenkins/barefoot/buildimage-bf-all/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/bldenv/docker-sonic-mgmt.Jenkinsfile
+++ b/jenkins/bldenv/docker-sonic-mgmt.Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/broadcom/buildimage-brcm-201904/Jenkinsfile
+++ b/jenkins/broadcom/buildimage-brcm-201904/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
 
     }
 

--- a/jenkins/broadcom/buildimage-brcm-all-pr/Jenkinsfile
+++ b/jenkins/broadcom/buildimage-brcm-all-pr/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '40'))
 
     }
 

--- a/jenkins/broadcom/buildimage-brcm-all-released-pr/Jenkinsfile
+++ b/jenkins/broadcom/buildimage-brcm-all-released-pr/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '40'))
 
     }
 

--- a/jenkins/broadcom/buildimage-brcm-all/Jenkinsfile
+++ b/jenkins/broadcom/buildimage-brcm-all/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/broadcom/buildimage-brcm-buster/Jenkinsfile
+++ b/jenkins/broadcom/buildimage-brcm-buster/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/centec-arm64/buildimage-centec-arm64-202012/Jenkinsfile
+++ b/jenkins/centec-arm64/buildimage-centec-arm64-202012/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/centec-arm64/buildimage-centec-arm64-all/Jenkinsfile
+++ b/jenkins/centec-arm64/buildimage-centec-arm64-all/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/centec/buildimage-centec-202012/Jenkinsfile
+++ b/jenkins/centec/buildimage-centec-202012/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/centec/buildimage-centec-all/Jenkinsfile
+++ b/jenkins/centec/buildimage-centec-all/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/generic/buildimage-baseimage-pr/Jenkinsfile
+++ b/jenkins/generic/buildimage-baseimage-pr/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '40'))
 
     }
 

--- a/jenkins/generic/buildimage-baseimage/Jenkinsfile
+++ b/jenkins/generic/buildimage-baseimage/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
 
     }
 

--- a/jenkins/innovium/buildimage-invm-201811-rpc/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-201811-rpc/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
 
     }
 

--- a/jenkins/innovium/buildimage-invm-201811/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-201811/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
 
     }
 

--- a/jenkins/innovium/buildimage-invm-201911-rpc/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-201911-rpc/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
 
     }
 

--- a/jenkins/innovium/buildimage-invm-201911/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-201911/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/innovium/buildimage-invm-202006-rpc/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-202006-rpc/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
 
     }
 

--- a/jenkins/innovium/buildimage-invm-202006/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-202006/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/innovium/buildimage-invm-202012-rpc/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-202012-rpc/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
 
     }
 

--- a/jenkins/innovium/buildimage-invm-202012/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-202012/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/innovium/buildimage-invm-all-rpc/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-all-rpc/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
 
     }
 

--- a/jenkins/innovium/buildimage-invm-all/Jenkinsfile
+++ b/jenkins/innovium/buildimage-invm-all/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/marvell-armhf/buildimage-mrvl-armhf-202012/Jenkinsfile
+++ b/jenkins/marvell-armhf/buildimage-mrvl-armhf-202012/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
         disableConcurrentBuilds()
     }
 

--- a/jenkins/marvell-armhf/buildimage-mrvl-armhf-all/Jenkinsfile
+++ b/jenkins/marvell-armhf/buildimage-mrvl-armhf-all/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
         disableConcurrentBuilds()
     }
 

--- a/jenkins/marvell/buildimage-mrvl-201911-rpc/Jenkinsfile
+++ b/jenkins/marvell/buildimage-mrvl-201911-rpc/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
 
     }
 

--- a/jenkins/marvell/buildimage-mrvl-201911/Jenkinsfile
+++ b/jenkins/marvell/buildimage-mrvl-201911/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/marvell/buildimage-mrvl-202012-rpc/Jenkinsfile
+++ b/jenkins/marvell/buildimage-mrvl-202012-rpc/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
 
     }
 

--- a/jenkins/marvell/buildimage-mrvl-202012/Jenkinsfile
+++ b/jenkins/marvell/buildimage-mrvl-202012/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/marvell/buildimage-mrvl-all-rpc/Jenkinsfile
+++ b/jenkins/marvell/buildimage-mrvl-all-rpc/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
 
     }
 

--- a/jenkins/marvell/buildimage-mrvl-all/Jenkinsfile
+++ b/jenkins/marvell/buildimage-mrvl-all/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/mellanox/buildimage-mlnx-201811-rpc/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-201811-rpc/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/mellanox/buildimage-mlnx-201811/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-201811/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/mellanox/buildimage-mlnx-201904/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-201904/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
 
     }
 

--- a/jenkins/mellanox/buildimage-mlnx-201911-rpc/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-201911-rpc/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/mellanox/buildimage-mlnx-201911/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-201911/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/mellanox/buildimage-mlnx-202012-rpc/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-202012-rpc/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/mellanox/buildimage-mlnx-202012/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-202012/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/mellanox/buildimage-mlnx-all-pr/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-all-pr/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '40'))
     }
 
     stages {

--- a/jenkins/mellanox/buildimage-mlnx-all-released-pr/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-all-released-pr/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '40'))
     }
 
     stages {

--- a/jenkins/mellanox/buildimage-mlnx-all/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-all/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/mellanox/buildimage-mlnx-bmtor-rpc/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-bmtor-rpc/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     triggers {

--- a/jenkins/mellanox/buildimage-mlnx-bmtor/Jenkinsfile
+++ b/jenkins/mellanox/buildimage-mlnx-bmtor/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     triggers {

--- a/jenkins/mgmt/sonic-mgmt-canary/Jenkinsfile
+++ b/jenkins/mgmt/sonic-mgmt-canary/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     triggers {

--- a/jenkins/mgmt/sonic-mgmt-pr/Jenkinsfile
+++ b/jenkins/mgmt/sonic-mgmt-pr/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '40'))
     }
 
     stages {

--- a/jenkins/nephos/buildimage-nps-201811/Jenkinsfile
+++ b/jenkins/nephos/buildimage-nps-201811/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
 
     }
 

--- a/jenkins/nephos/buildimage-nps-201911/Jenkinsfile
+++ b/jenkins/nephos/buildimage-nps-201911/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/nephos/buildimage-nps-202012/Jenkinsfile
+++ b/jenkins/nephos/buildimage-nps-202012/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/nephos/buildimage-nps-all/Jenkinsfile
+++ b/jenkins/nephos/buildimage-nps-all/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-workers-slow' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/vs/buildimage-multiasic-vs-image-201911/Jenkinsfile
+++ b/jenkins/vs/buildimage-multiasic-vs-image-201911/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-kvm-workers' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/vs/buildimage-vs-all-pr/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-all-pr/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-build-workers' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '40'))
 
     }
 

--- a/jenkins/vs/buildimage-vs-all/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-all/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-build-workers' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/vs/buildimage-vs-image-201904/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-201904/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-kvm-workers' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
 
     }
 

--- a/jenkins/vs/buildimage-vs-image-201911-test/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-201911-test/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/vs/buildimage-vs-image-201911/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-201911/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-kvm-workers' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/vs/buildimage-vs-image-202012/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-202012/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-kvm-workers' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/vs/buildimage-vs-image-buster/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-buster/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-build-workers' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-pr/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-build-workers' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '40'))
     }
 
     stages {

--- a/jenkins/vs/buildimage-vs-image-released-pr/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-released-pr/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-kvm-workers' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '60'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '40'))
 
     }
 

--- a/jenkins/vs/buildimage-vs-image-test/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image-test/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {

--- a/jenkins/vs/buildimage-vs-image/Jenkinsfile
+++ b/jenkins/vs/buildimage-vs-image/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { node { label 'jenkins-build-workers' } }
 
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '30'))
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20'))
     }
 
     environment {


### PR DESCRIPTION
To reduce Jenkins master disk storage
Change log keep history: 60 -> 40, 30 -> 20
Otherwise, we need to clean some log by hand periodly.