### PR TITLE
[201911] install pyroute2

### DIFF
--- a/scripts/common/sonic-utilities-build/build_201911.sh
+++ b/scripts/common/sonic-utilities-build/build_201911.sh
@@ -22,6 +22,7 @@ sudo pip2 install netifaces==0.10.9
 sudo pip2 install pytest-runner==4.4
 sudo pip2 install xmltodict==0.12.0
 sudo pip2 install jsondiff==1.2.0
+sudo pip2 install pyroute2==0.5.14
 
 cd sonic-utilities
 


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

`pyroute2` was added to image in this PR https://github.com/Azure/sonic-buildimage/pull/6792
Install `pyroute2` in the sonic-utilities  PR  build script. 